### PR TITLE
adding mock location support to settings apk

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -17,6 +17,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service android:exported="true" android:name=".LocationService"> </service>
     </application>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
@@ -28,4 +29,5 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS"/>
+    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
 </manifest>

--- a/src/io/appium/settings/LocationService.java
+++ b/src/io/appium/settings/LocationService.java
@@ -1,0 +1,28 @@
+package io.appium.settings;
+
+import android.app.Service;
+import android.content.Intent;
+import android.location.LocationManager;
+import android.os.IBinder;
+import android.util.Log;
+
+public class LocationService extends Service {
+
+    MockLocationProvider mock;
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        String longitude = intent.getStringExtra("longitude");
+        String latitude = intent.getStringExtra("latitude");
+        Log.i("LocationService", "setting the location from service with longitude: "+longitude+" latitude: "+latitude);
+        mock = new MockLocationProvider(LocationManager.GPS_PROVIDER, this);
+        // Set mock location
+        mock.pushLocation(Double.valueOf(latitude), Double.valueOf(longitude));
+        return START_NOT_STICKY;
+    }
+}

--- a/src/io/appium/settings/MockLocationProvider.java
+++ b/src/io/appium/settings/MockLocationProvider.java
@@ -1,0 +1,34 @@
+package io.appium.settings;
+
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationManager;
+import android.os.SystemClock;
+
+public class MockLocationProvider {
+    String providerName;
+    Context ctx;
+
+    public MockLocationProvider(String name, Context ctx) {
+        this.providerName = name;
+        this.ctx = ctx;
+    }
+
+    public void pushLocation(double lat, double lon) {
+        LocationManager lm = (LocationManager) ctx.getSystemService(
+                Context.LOCATION_SERVICE);
+        lm.addTestProvider(providerName, false, false, false, false, false,
+                false, true, 0, 5);
+        lm.setTestProviderEnabled(providerName, true);
+
+        Location mockLocation = new Location(providerName);
+        mockLocation.setLatitude(lat);
+        mockLocation.setLongitude(lon);
+        mockLocation.setAltitude(0);
+        mockLocation.setTime(System.currentTimeMillis());
+        mockLocation.setAccuracy(1);
+        mockLocation.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
+
+        lm.setTestProviderLocation(providerName, mockLocation);
+    }
+}


### PR DESCRIPTION
#### Commit summary: 

* This commit addresses the issue [appium #4309] (https://github.com/appium/appium/issues/4309)
* The code changes include the usage of `android.location.LocationManager` to add the ability to mock the location on device.
* Added service with the name `LocationService` that will be invoked from appium node server. [(appium PR)] (https://github.com/appium/appium/pull/6094)