### PR TITLE
Remove unnecessary verification for location service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 17
         targetSdkVersion 23
-        versionCode 2
-        versionName "2.0"
+        versionCode 3
+        versionName "2.1"
         applicationId "io.appium.settings"
     }
 

--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -18,7 +18,6 @@ package io.appium.settings;
 
 import android.app.Service;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.location.LocationManager;
 import android.os.IBinder;
@@ -34,13 +33,9 @@ public class LocationService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        if ((getApplication().getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
-            Log.e(TAG, "Location mocking only works in debug mode");
-            return START_NOT_STICKY;
-        }
         for (String p : new String[]{
                 "android.permission.ACCESS_COARSE_LOCATION",
-                "android.permission.ACCESS_MOCK_LOCATION"}) {
+                "android.permission.ACCESS_FINE_LOCATION"}) {
             if (getApplicationContext().checkCallingOrSelfPermission(p)
                     != PackageManager.PERMISSION_GRANTED) {
                 Log.e(TAG, String.format("Cannot mock location due to missing permission '%s'", p));


### PR DESCRIPTION
We anyway don't need this verification, since the app is always built in debug mode only and it seems like it does not always work as expected. See https://github.com/appium/appium/issues/8164#issuecomment-291500029 for the reference  