### PR TITLE
implement locale setting handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Set particular locale:
 $ adb shell am broadcast -a io.appium.settings.locale --es lang ja --es country JP
 ```
 
+You can set the [Locale](https://developer.android.com/reference/java/util/Locale.html) format, especially this feature support [Locale(String language, String country)](https://developer.android.com/reference/java/util/Locale.html#Locale(java.lang.String,%20java.lang.String)) so far.
+
 ## Notes:
 
 * You have to specify the receiver class if app never executed before:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ adb shell am broadcast -a io.appium.settings.animation --es setstatus disable
 Set particular locale:
 
 ```shell
-$ adb shell am broadcast -a io.appium.settings.locale --es LANG ja --es COUNTRY JP
+$ adb shell am broadcast -a io.appium.settings.locale --es lang ja --es country JP
 ```
 
 ## Notes:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ To turn off `animation`:
 $ adb shell am broadcast -a io.appium.settings.animation --es setstatus disable
 ```
 
+Set particular locale:
+
+```shell
+$ adb shell am broadcast -a io.appium.settings.locale --es LANG ja --es COUNTRY JP
+```
+
 ## Notes:
 
 * You have to specify the receiver class if app never executed before:
@@ -86,6 +92,10 @@ $ adb shell am broadcast -a io.appium.settings.wifi -n io.appium.settings/.recei
 * To change animation setting, app should be granted `SET_ANIMATION_SCALE` permission:
 ```shell
 $ adb shell pm grant io.appium.settings android.permission.SET_ANIMATION_SCALE
+```
+* To change locale setting, app should be granted `CHANGE_CONFIGURATION` permission:
+```shell
+$ adb shell pm grant io.appium.settings android.permission.CHANGE_CONFIGURATION
 ```
 
 * On Android 6.0+ you must enable the corresponding permissions for the app first. This can be

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 17
         targetSdkVersion 23
-        versionCode 4
-        versionName "2.2"
+        versionCode 5
+        versionName "2.3"
         applicationId "io.appium.settings"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
     <uses-permission android:name="android.permission.SET_ANIMATION_SCALE" />
+    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
 
     <uses-feature android:name="android.hardware.wifi" />
 
@@ -54,6 +55,12 @@
         <receiver android:name=".receivers.AnimationSettingReceiver">
             <intent-filter>
                 <action android:name="io.appium.settings.animation" />
+            </intent-filter>
+        </receiver>
+
+        <receiver android:name=".receivers.LocaleSettingReceiver">
+            <intent-filter>
+                <action android:name="io.appium.settings.locale" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/java/io/appium/settings/handlers/LocaleSettingHandler.java
+++ b/app/src/main/java/io/appium/settings/handlers/LocaleSettingHandler.java
@@ -1,0 +1,83 @@
+/*
+  Copyright 2012-present Appium Committers
+  <p>
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  <p>
+  http://www.apache.org/licenses/LICENSE-2.0
+  <p>
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+package io.appium.settings.handlers;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.res.Configuration;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+public class LocaleSettingHandler {
+    private static final String TAG = "APPIUM SETTINGS(LOCALE)";
+    private static final String ANIMATION_PERMISSION = "android.permission.CHANGE_CONFIGURATION";
+
+    private Context context;
+
+    public LocaleSettingHandler(Context context) {
+        this.context = context;
+    }
+
+    private boolean hasPermissions() {
+        if (context.checkCallingOrSelfPermission(ANIMATION_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
+            String logMessage = String.format("The permission %s is not set. Cannot change state of %s.",
+                    ANIMATION_PERMISSION, "mobile locale");
+            Log.e(TAG, logMessage);
+            return false;
+        }
+        return true;
+    }
+
+    public void setLocale(Locale locale) {
+        try {
+            if(hasPermissions()) {
+                setLocaleWith(locale);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to set locale", e);
+        }
+    }
+
+    private void setLocaleWith(Locale locale) throws
+            ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
+        Class<?> activityManagerNativeClass = Class.forName("android.app.ActivityManagerNative");
+        Object amn;
+        Configuration config;
+
+        Method methodGetDefault = activityManagerNativeClass.getMethod("getDefault");
+        methodGetDefault.setAccessible(true);
+        amn = methodGetDefault.invoke(activityManagerNativeClass);
+
+        Method methodGetConfiguration = activityManagerNativeClass.getMethod("getConfiguration");
+        methodGetConfiguration.setAccessible(true);
+        config = (Configuration) methodGetConfiguration.invoke(amn);
+
+        Class<?> configClass = config.getClass();
+        Field f = configClass.getField("userSetLocale");
+        f.setBoolean(config, true);
+
+        config.locale = locale;
+
+        Method methodUpdateConfiguration = activityManagerNativeClass.getMethod("updateConfiguration", Configuration.class);
+        methodUpdateConfiguration.setAccessible(true);
+        methodUpdateConfiguration.invoke(amn, config);
+    }
+}

--- a/app/src/main/java/io/appium/settings/handlers/LocaleSettingHandler.java
+++ b/app/src/main/java/io/appium/settings/handlers/LocaleSettingHandler.java
@@ -48,12 +48,10 @@ public class LocaleSettingHandler extends AbstractSettingHandler {
     private void setLocaleWith(Locale locale) throws
             ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
         Class<?> activityManagerNativeClass = Class.forName("android.app.ActivityManagerNative");
-        Object amn;
-        Configuration config;
 
         Method methodGetDefault = activityManagerNativeClass.getMethod("getDefault");
         methodGetDefault.setAccessible(true);
-        amn = methodGetDefault.invoke(activityManagerNativeClass);
+        Object amn = methodGetDefault.invoke(activityManagerNativeClass);
 
         // Build.VERSION_CODES.O
         if (Build.VERSION.SDK_INT >= 26) {
@@ -63,7 +61,7 @@ public class LocaleSettingHandler extends AbstractSettingHandler {
 
         Method methodGetConfiguration = activityManagerNativeClass.getMethod("getConfiguration");
         methodGetConfiguration.setAccessible(true);
-        config = (Configuration) methodGetConfiguration.invoke(amn);
+        Configuration config = (Configuration) methodGetConfiguration.invoke(amn);
 
         Class<?> configClass = config.getClass();
         Field f = configClass.getField("userSetLocale");

--- a/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
@@ -45,6 +45,9 @@ public class LocaleSettingReceiver extends BroadcastReceiver {
         String language = intent.getStringExtra(LANG);
         String country = intent.getStringExtra(COUNTRY);
 
+        // Expect https://developer.android.com/reference/java/util/Locale.html#Locale(java.lang.String,%20java.lang.String) format.
+        // If we'd like to extend the other format like `Locale(String language, String country, String variant)`,
+        // you can implement it around here.
         Locale locale = new Locale(language, country);
 
         LocaleSettingHandler localeSettingHandler = new LocaleSettingHandler(context);

--- a/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
@@ -19,6 +19,7 @@ package io.appium.settings.receivers;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 
 import java.util.Locale;
 
@@ -27,12 +28,20 @@ import io.appium.settings.handlers.LocaleSettingHandler;
 public class LocaleSettingReceiver extends BroadcastReceiver {
     private static final String TAG = LocaleSettingReceiver.class.getSimpleName();
 
-    private static final String LANG = "LANG";
-    private static final String COUNTRY = "COUNTRY";
+    private static final String LANG = "lang";
+    private static final String COUNTRY = "country";
 
-    // am broadcast -a io.appium.settings.locale --es LANG ja --es COUNTRY JP
+    // am broadcast -a io.appium.settings.locale --es lang ja --es country JP
     @Override
     public void onReceive(Context context, Intent intent) {
+        if(!hasExtraLocale(intent)) {
+            Log.e(TAG, "Don't forget to set land and country like: am broadcast -a io.appium.settings.locale --es lang ja --es country JP");
+            Log.e(TAG, "Set en-US by default.");
+
+            intent.putExtra(LANG, "en");
+            intent.putExtra(COUNTRY, "US");
+        }
+
         String language = intent.getStringExtra(LANG);
         String country = intent.getStringExtra(COUNTRY);
 
@@ -41,5 +50,9 @@ public class LocaleSettingReceiver extends BroadcastReceiver {
         LocaleSettingHandler localeSettingHandler = new LocaleSettingHandler(context);
 
         localeSettingHandler.setLocale(locale);
+    }
+
+    private boolean hasExtraLocale(Intent intent) {
+        return intent.hasExtra(LANG) && intent.hasExtra(COUNTRY);
     }
 }

--- a/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
@@ -35,7 +35,7 @@ public class LocaleSettingReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if(!hasExtraLocale(intent)) {
-            Log.e(TAG, "Don't forget to set land and country like: am broadcast -a io.appium.settings.locale --es lang ja --es country JP");
+            Log.e(TAG, "Don't forget to set lang and country like: am broadcast -a io.appium.settings.locale --es lang ja --es country JP");
             Log.e(TAG, "Set en-US by default.");
 
             intent.putExtra(LANG, "en");

--- a/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
@@ -1,0 +1,45 @@
+/*
+  Copyright 2012-present Appium Committers
+  <p>
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  <p>
+  http://www.apache.org/licenses/LICENSE-2.0
+  <p>
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+package io.appium.settings.receivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import java.util.Locale;
+
+import io.appium.settings.handlers.LocaleSettingHandler;
+
+public class LocaleSettingReceiver extends BroadcastReceiver {
+    private static final String TAG = LocaleSettingReceiver.class.getSimpleName();
+
+    private static final String LANG = "LANG";
+    private static final String COUNTRY = "COUNTRY";
+
+    // am broadcast -a io.appium.settings.locale --es LANG ja --es COUNTRY JP
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String language = intent.getStringExtra(LANG);
+        String country = intent.getStringExtra(COUNTRY);
+
+        Locale locale = new Locale(language, country);
+
+        LocaleSettingHandler localeSettingHandler = new LocaleSettingHandler(context);
+
+        localeSettingHandler.setLocale(locale);
+    }
+}


### PR DESCRIPTION
We can change the device's locale with the following commands:

```
$ adb shell pm grant io.appium.settings android.permission.CHANGE_CONFIGURATION
$ adb shell am broadcast -a io.appium.settings.locale --es LANG ja --es COUNTRY JP
```

We can change the device locale for Android O, N and the below.
So, we can avoid the crash like [Change locale cause appium to crash in Android N and O](https://github.com/appium/appium/issues/9619) if we change the locale with this feature.