### PR TITLE
add a note for Android P

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ StackOveflow thread for more details.
 Voila!
 
 ### Android P
-- Android P has [ristrictions on non-SDK interfaces](https://developer.android.com/preview/restrictions-non-sdk-interfaces).
+- Android P has [restrictions on non-SDK interfaces](https://developer.android.com/preview/restrictions-non-sdk-interfaces).
 - We use `setAnimationScales` in `AnimationSettingHandler.java`, for example. If Appium runs the method via turn on/off animation feature, `java.lang.NoSuchMethodException: setAnimationScales` happens since the interface is non-sdk interface.
 - To avoid the error, we should run below before calling them.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ StackOveflow thread for more details.
 
 Voila!
 
+### Android P
+- Android P has [ristrictions on non-SDK interfaces](https://developer.android.com/preview/restrictions-non-sdk-interfaces).
+- We use `setAnimationScales` in `AnimationSettingHandler.java`, for example. If Appium runs the method via turn on/off animation feature, `java.lang.NoSuchMethodException: setAnimationScales` happens since the interface is non-sdk interface.
+- To avoid the error, we should run below before calling them.
+
+```
+adb shell settings put global hidden_api_policy_pre_p_apps  1
+adb shell settings put global hidden_api_policy_p_apps 1
+```
+
+Read https://developer.android.com/preview/restrictions-non-sdk-interfaces for more details to understand further.
+
 ## Caveats
 
 There are certain system services which cannot be accessed through an application. Two ones central here are `airplane_mode` and `gps`.


### PR DESCRIPTION
We use non-SDK interface in appium settings. So, on Android P, some exception will happen.
I added a note for it to avoid the exception.

`How can I enable access to non-SDK APIs?` in https://developer.android.com/preview/restrictions-non-sdk-interfaces#general_questions help this issue.


I'd like to add the adb command in https://github.com/appium/appium-adb and call it after installing io.appium.settings.
I'm also thinking to avoid unexpected calling `hidden_api_policy_pre_p_apps`, we should set capability if appium call the command before tests.
Anyway, this PR has only a note for Android P. <= It isn't API level 28. Emulators provided as API Level 28 doesn't provide non-SDK related issue since the non-SDK related exception only happens Android P emulator before it became API Level 28 based.