### PR TITLE
Update .npmignore to exclude the unnecessary stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 *.iml
 local.properties
 package-lock.json
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,9 @@
 bin/*
 !bin/settings_apk-debug.apk
 gen
+build
+.idea
+.gradle
+app/build/*
+!app/build/outputs/apk/settings_apk-debug.apk
+

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-bin/*
-!bin/settings_apk-debug.apk
-gen
-build
-.idea
-.gradle
-app/build/*
-!app/build/outputs/apk/settings_apk-debug.apk
-

--- a/package.json
+++ b/package.json
@@ -15,6 +15,14 @@
     "android",
     "settings"
   ],
+  "files": [
+    "index.js",
+    "gradle*",
+    "build.gradle",
+    "settings.gradle",
+    "app/",
+    "gradle/"
+  ],
   "author": "https://github.com/appium",
   "license": "Apache-2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "gradle*",
     "build.gradle",
     "settings.gradle",
-    "app/",
+    "app/build.gradle",
+    "app/build/outputs/apk/",
+    "app/src/",
     "gradle/"
   ],
   "author": "https://github.com/appium",


### PR DESCRIPTION
This will allow to save ~100 MB (!) while publishing the package to npm