### PR TITLE
Remove babel dep

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@
 const gulp = require('gulp');
 const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
 
+
 boilerplate({
   build: 'io.appium.settings',
 });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "homepage": "https://github.com/appium/io.appium.settings",
   "devDependencies": {
-    "@babel/runtime": "^7.0.0",
     "appium-gulp-plugins": "^3.1.0",
     "gulp": "^4.0.0"
   }


### PR DESCRIPTION
There is no transpilation in this package, so no need for any babel stuff. This will reduce the builds from Greenkeeper, too.