### PR TITLE
fixing app crash on location change

### DIFF
--- a/app/src/main/java/io/appium/settings/ForegroundService.java
+++ b/app/src/main/java/io/appium/settings/ForegroundService.java
@@ -20,14 +20,17 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.RequiresApi;
 import android.support.v4.app.NotificationCompat;
+import android.util.Log;
 
 public class ForegroundService extends Service {
+    private static final String TAG = "APPIUM SERVICE";
     public static final String ACTION_START = "start";
     public static final String ACTION_STOP = "stop";
     private static final String CHANNEL_ID = "main_channel";
@@ -87,5 +90,12 @@ public class ForegroundService extends Service {
     private void stopForegroundService() {
         stopForeground(true);
         stopSelf();
+    }
+
+    public static Intent getForegroundServiceIntent(Context context) {
+        Log.d(TAG, "Initializing the foreground service");
+        Intent intent = new Intent(context, ForegroundService.class);
+        intent.setAction(ForegroundService.ACTION_START);
+        return intent;
     }
 }

--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -88,7 +88,7 @@ public class LocationService extends Service {
 
         handleIntent(intent);
 
-        return START_NOT_STICKY;
+        return START_STICKY;
     }
 
     @Override

--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -82,7 +82,7 @@ public class LocationService extends Service {
         // https://stackoverflow.com/a/45047542
         // https://developer.android.com/about/versions/oreo/android-8.0-changes.html
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Log.w(TAG, "Starting location service");
+            Log.i(TAG, "Starting location service");
             startService(ForegroundService.getForegroundServiceIntent(LocationService.this));
         }
 

--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -16,15 +16,22 @@
 
 package io.appium.settings;
 
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.graphics.BitmapFactory;
 import android.location.Criteria;
 import android.location.Location;
 import android.location.LocationManager;
 import android.location.LocationProvider;
+import android.os.Build;
 import android.os.IBinder;
+import android.support.annotation.RequiresApi;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 import com.google.android.gms.common.api.GoogleApiClient;
@@ -56,9 +63,29 @@ public class LocationService extends Service {
     private final Timer locationUpdatesTimer = new Timer();
     private TimerTask locationUpdateTask;
 
+    public static final String ACTION_START = "start";
+    public static final String ACTION_STOP = "stop";
+    private static final String CHANNEL_ID = "main_channel";
+    private static final String CHANNEL_NAME = "Appium Settings";
+    private static final String CHANNEL_DESCRIPTION = "Keep this service running, " +
+            "so Appium for Android can properly interact with several system APIs";
+
     @Override
     public IBinder onBind(Intent intent) {
         return null;
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private void createChannel() {
+        NotificationManager mNotificationManager = (NotificationManager) this.getSystemService(NOTIFICATION_SERVICE);
+        if (mNotificationManager == null) {
+            return;
+        }
+        NotificationChannel mChannel = new NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT);
+        mChannel.setDescription(CHANNEL_DESCRIPTION);
+        mChannel.setShowBadge(true);
+        mChannel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);
+        mNotificationManager.createNotificationChannel(mChannel);
     }
 
     @Override
@@ -77,9 +104,27 @@ public class LocationService extends Service {
                 return START_NOT_STICKY;
             }
         }
+        startForegroundService();
+
         handleIntent(intent);
 
         return START_NOT_STICKY;
+    }
+
+    private void startForegroundService() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createChannel();
+        }
+        NotificationCompat.BigTextStyle bigTextStyle = new NotificationCompat.BigTextStyle();
+        bigTextStyle.setBigContentTitle(CHANNEL_NAME);
+        bigTextStyle.bigText(CHANNEL_DESCRIPTION);
+        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setStyle(bigTextStyle)
+                .setWhen(System.currentTimeMillis())
+                .setSmallIcon(R.drawable.ic_launcher)
+                .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.drawable.ic_launcher))
+                .build();
+        startForeground(2, notification);
     }
 
     @Override

--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -18,7 +18,6 @@ package io.appium.settings;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;
-import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Bundle;
@@ -56,10 +55,7 @@ public class Settings extends Activity {
 
         // https://developer.android.com/about/versions/oreo/background-location-limits
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Log.d(TAG, "Initializing the foreground service");
-            Intent intent = new Intent(Settings.this, ForegroundService.class);
-            intent.setAction(ForegroundService.ACTION_START);
-            startService(intent);
+            startService(ForegroundService.getForegroundServiceIntent(Settings.this));
         }
 
         Log.d(TAG, "Closing the app");


### PR DESCRIPTION
Fixing crash when trying to set the location on Pie emulator

Adb command 
```bash
adb shell am start-foreground-service --user 0 -n io.appium.settings/.LocationService --es longitude -87.12733 --es latitude 15.13697
```

Crash log
```
--------- beginning of crash
08-07 11:16:02.437 E/AndroidRuntime( 6577): FATAL EXCEPTION: main
08-07 11:16:02.437 E/AndroidRuntime( 6577): Process: io.appium.settings, PID: 6577
08-07 11:16:02.437 E/AndroidRuntime( 6577): android.app.RemoteServiceException: Context.startForegroundService() did not then call Service.startForeground()
08-07 11:16:02.437 E/AndroidRuntime( 6577):     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1775)
08-07 11:16:02.437 E/AndroidRuntime( 6577):     at android.os.Handler.dispatchMessage(Handler.java:105)
08-07 11:16:02.437 E/AndroidRuntime( 6577):     at android.os.Looper.loop(Looper.java:164)
08-07 11:16:02.437 E/AndroidRuntime( 6577):     at android.app.ActivityThread.main(ActivityThread.java:6541)
08-07 11:16:02.437 E/AndroidRuntime( 6577):     at java.lang.reflect.Method.invoke(Native Method)
08-07 11:16:02.437 E/AndroidRuntime( 6577):     at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
08-07 11:16:02.437 E/AndroidRuntime( 6577):     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
08-07 11:16:02.464 D/gralloc_ranchu( 1438): gralloc_alloc: Creating ashmem region of size 2289664
08-07 11:16:02.470 D/        ( 6921): HostConnection::get() New Host Connection established 0x7db95082f780, tid 6921
08-07 11:16:02.479 E/EGL_emulation( 1448): tid 1448: eglCreateSyncKHR(2049): error 0x3004 (EGL_BAD_ATTRIBUTE)
08-07 11:16:02.485 I/ActivityManager( 1792): Showing crash dialog for package io.appium.settings u0
08-07 11:16:02.546 D/gralloc_ranchu( 1438): gralloc_alloc: Creating ashmem region of size 1024000
08-07 11:16:02.549 I/chatty  ( 1438): uid=1000(system) allocator@2.0-s identical 1 line
08-07 11:16:02.551 D/gralloc_ranchu( 1438): gralloc_alloc: Creating ashmem region of size 1024000
08-07 11:16:02.594 D/gralloc_ranchu( 1438): gralloc_alloc: Creating ashmem region of size 770048
08-07 11:16:02.598 I/chatty  ( 1438): uid=1000(system) allocator@2.0-s identical 1 line
08-07 11:16:02.601 D/gralloc_ranchu( 1438): gralloc_alloc: Creating ashmem region of size 770048
08-07 11:16:02.620 D/EGL_emulation( 1792): eglMakeCurrent: 0x76cd36681f00: ver 2 0 (tinfo 0x76cd3253dfa0)
08-07 11:16:02.625 I/zygote64( 1792): Background concurrent copying GC freed 75006(3MB) AllocSpace objects, 23(2MB) LOS objects, 34% free, 11MB/17MB, paused 530us total 173.842ms
```