### PR TITLE
feat: Add a broadcast service to receive the clipboard content

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A small and simple Android application that deals with the system settings. Then
 
 ## Requirements
 
-* [Android SDK](developer.android.com)
+* [Android SDK](http://developer.android.com)
 * [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * [Gradle](https://gradle.org/)
 
@@ -148,21 +148,37 @@ adb shell ime set io.appium.settings/.UnicodeIME
 ```
 
 
+## Clipboard
+
+This action allows to retrieve the text content of the current clipboard.
+An empty string is returned if the clipboard cannot be retrieved
+or the clipboard is empty. 
+Remember, that since Android Q the clipboard content can only be retrieved if
+the requester application is set as the default IME in the system:
+
+```bash
+adb shell ime enable io.appium.settings/.AppiumIME
+adb shell ime set io.appium.settings/.AppiumIME
+adb shell am broadcast -a io.appium.settings.clipboard.get
+adb shell ime set com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME
+```
+
+
 ## Notes:
 
-* You have to specify the receiver class if app never executed before:
+* You have to specify the receiver class if the app has never been executed before:
 ```shell
 $ adb shell am broadcast -a io.appium.settings.wifi -n io.appium.settings/.receivers.WiFiConnectionSettingReceiver --es setstatus disable
 ```
-* To change animation setting, app should be granted `SET_ANIMATION_SCALE` permission:
+* To change animation setting, the app should be granted `SET_ANIMATION_SCALE` permission:
 ```shell
 $ adb shell pm grant io.appium.settings android.permission.SET_ANIMATION_SCALE
 ```
-* To change locale setting, app should be granted `CHANGE_CONFIGURATION` permission:
+* To change locale setting, the app should be granted `CHANGE_CONFIGURATION` permission:
 ```shell
 $ adb shell pm grant io.appium.settings android.permission.CHANGE_CONFIGURATION
 ```
-* To get location, app should be granted `ACCESS_FINE_LOCATION` permission at least:
+* To get location, the app should be granted `ACCESS_FINE_LOCATION` permission at least:
 ```shell
 $ adb shell pm grant io.appium.settings android.permission.ACCESS_FINE_LOCATION
 ```

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ adb shell ime set io.appium.settings/.UnicodeIME
 
 ## Clipboard
 
-This action allows to retrieve the text content of the current clipboard.
+This action allows to retrieve the text content of the current clipboard
+as base64-encoded string.
 An empty string is returned if the clipboard cannot be retrieved
 or the clipboard is empty. 
 Remember, that since Android Q the clipboard content can only be retrieved if

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 17
         targetSdkVersion 28
         versionCode 19
         versionName "2.14.2"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode 19
         versionName "2.14.2"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,6 +105,9 @@
         <receiver android:name=".receivers.LocaleSettingReceiver"
             android:exported="true"
             tools:ignore="ExportedReceiver" />
+        <receiver android:name=".receivers.ClipboardReceiver"
+                  android:exported="true"
+                  tools:ignore="ExportedReceiver" />
         <receiver android:name=".receivers.LocationInfoReceiver"
             android:exported="true"
             tools:ignore="ExportedReceiver" />

--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.appium.settings.receivers.AnimationSettingReceiver;
+import io.appium.settings.receivers.ClipboardReceiver;
 import io.appium.settings.receivers.DataConnectionSettingReceiver;
 import io.appium.settings.receivers.HasAction;
 import io.appium.settings.receivers.LocaleSettingReceiver;
@@ -51,6 +52,7 @@ public class Settings extends Activity {
         receiverClasses.add(DataConnectionSettingReceiver.class);
         receiverClasses.add(LocaleSettingReceiver.class);
         receiverClasses.add(LocationInfoReceiver.class);
+        receiverClasses.add(ClipboardReceiver.class);
         registerSettingsReceivers(receiverClasses);
 
         // https://developer.android.com/about/versions/oreo/background-location-limits

--- a/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
@@ -39,7 +39,11 @@ public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
     private String getClipboardText(Context context) {
         final ClipboardManager cm = (ClipboardManager) context
                 .getSystemService(Context.CLIPBOARD_SERVICE);
-        if (cm == null || !cm.hasPrimaryClip()) {
+        if (cm == null) {
+            Log.e(TAG, "Cannot get an instance of ClipboardManager");
+            return null;
+        }
+        if (!cm.hasPrimaryClip()) {
             return "";
         }
         final ClipData cd = cm.getPrimaryClip();
@@ -58,8 +62,11 @@ public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
     @Override
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "Getting current clipboard content");
-        setResultCode(Activity.RESULT_OK);
         String clipboardContent = getClipboardText(context);
+        if (clipboardContent == null) {
+            setResultCode(Activity.RESULT_CANCELED);
+            clipboardContent = "";
+        }
         String clipboardContentBase64 = "";
         try {
             // TODO: Use StandardCharsets.UTF_8 after the minimum supported API version
@@ -67,7 +74,9 @@ public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
             //noinspection CharsetObjectCanBeUsed
             clipboardContentBase64 = Base64.encodeToString(
                     clipboardContent.getBytes("UTF-8"), Base64.DEFAULT);
+            setResultCode(Activity.RESULT_OK);
         } catch (UnsupportedEncodingException e) {
+            setResultCode(Activity.RESULT_CANCELED);
             e.printStackTrace();
         }
         setResultData(clipboardContentBase64);

--- a/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
@@ -25,7 +25,7 @@ import android.content.Intent;
 import android.util.Base64;
 import android.util.Log;
 
-import java.nio.charset.StandardCharsets;
+import java.io.UnsupportedEncodingException;
 
 public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
     private static final String TAG = ClipboardReceiver.class.getSimpleName();
@@ -60,8 +60,16 @@ public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
         Log.d(TAG, "Getting current clipboard content");
         setResultCode(Activity.RESULT_OK);
         String clipboardContent = getClipboardText(context);
-        String clipboardContentBase64 = Base64.encodeToString(
-                clipboardContent.getBytes(StandardCharsets.UTF_8), Base64.DEFAULT);
+        String clipboardContentBase64 = "";
+        try {
+            // TODO: Use StandardCharsets.UTF_8 after the minimum supported API version
+            // TODO: is bumped above 18
+            //noinspection CharsetObjectCanBeUsed
+            clipboardContentBase64 = Base64.encodeToString(
+                    clipboardContent.getBytes("UTF-8"), Base64.DEFAULT);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
         setResultData(clipboardContentBase64);
     }
 

--- a/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
@@ -1,0 +1,66 @@
+/*
+  Copyright 2012-present Appium Committers
+  <p>
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  <p>
+  http://www.apache.org/licenses/LICENSE-2.0
+  <p>
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+package io.appium.settings.receivers;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
+    private static final String TAG = ClipboardReceiver.class.getSimpleName();
+
+    private static final String ACTION = "io.appium.settings.clipboard.get";
+
+    private static String charSequenceToString(CharSequence input) {
+        return input == null ? "" : input.toString();
+    }
+
+    private String getClipboardText(Context context) {
+        final ClipboardManager cm = (ClipboardManager) context
+                .getSystemService(Context.CLIPBOARD_SERVICE);
+        if (cm == null || !cm.hasPrimaryClip()) {
+            return "";
+        }
+        final ClipData cd = cm.getPrimaryClip();
+        if (cd == null || cd.getItemCount() == 0) {
+            return "";
+        }
+        return charSequenceToString(cd.getItemAt(0).coerceToText(context));
+    }
+
+    /**
+     * Responds to broadcast requests like
+     * am broadcast -a io.appium.settings.clipboard.get
+     * with the current textual clipboard content
+     * or empty string if no content has been received
+     */
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.d(TAG, "Getting current clipboard content");
+        setResultCode(Activity.RESULT_OK);
+        setResultData(getClipboardText(context));
+    }
+
+    @Override
+    public String getAction() {
+        return ACTION;
+    }
+}

--- a/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
@@ -62,24 +62,26 @@ public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
     @Override
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "Getting current clipboard content");
-        String clipboardContent = getClipboardText(context);
+        final String clipboardContent = getClipboardText(context);
         if (clipboardContent == null) {
             setResultCode(Activity.RESULT_CANCELED);
-            clipboardContent = "";
+            setResultData("");
+            return;
         }
-        String clipboardContentBase64 = "";
+
         try {
             // TODO: Use StandardCharsets.UTF_8 after the minimum supported API version
             // TODO: is bumped above 18
             //noinspection CharsetObjectCanBeUsed
-            clipboardContentBase64 = Base64.encodeToString(
+            String clipboardContentBase64 = Base64.encodeToString(
                     clipboardContent.getBytes("UTF-8"), Base64.DEFAULT);
             setResultCode(Activity.RESULT_OK);
+            setResultData(clipboardContentBase64);
         } catch (UnsupportedEncodingException e) {
-            setResultCode(Activity.RESULT_CANCELED);
             e.printStackTrace();
+            setResultCode(Activity.RESULT_CANCELED);
+            setResultData("");
         }
-        setResultData(clipboardContentBase64);
     }
 
     @Override

--- a/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/ClipboardReceiver.java
@@ -22,7 +22,10 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Base64;
 import android.util.Log;
+
+import java.nio.charset.StandardCharsets;
 
 public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
     private static final String TAG = ClipboardReceiver.class.getSimpleName();
@@ -49,14 +52,17 @@ public class ClipboardReceiver extends BroadcastReceiver implements HasAction {
     /**
      * Responds to broadcast requests like
      * am broadcast -a io.appium.settings.clipboard.get
-     * with the current textual clipboard content
-     * or empty string if no content has been received
+     * with the base64-encoded current clipboard text content
+     * or an empty string if no content has been received
      */
     @Override
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "Getting current clipboard content");
         setResultCode(Activity.RESULT_OK);
-        setResultData(getClipboardText(context));
+        String clipboardContent = getClipboardText(context);
+        String clipboardContentBase64 = Base64.encodeToString(
+                clipboardContent.getBytes(StandardCharsets.UTF_8), Base64.DEFAULT);
+        setResultData(clipboardContentBase64);
     }
 
     @Override


### PR DESCRIPTION
The next step would be to change ADB to set Appium Settings as default IME before getting the clipboard content for Android Q+
See https://github.com/appium/appium/issues/13466 for more details