### PR TITLE
fix: Fall back to non-GPS location services when requestLocationUpdates returns null

### DIFF
--- a/app/src/main/java/io/appium/settings/LocationTracker.java
+++ b/app/src/main/java/io/appium/settings/LocationTracker.java
@@ -269,7 +269,8 @@ public class LocationTracker implements GoogleApiClient.ConnectionCallbacks,
             }
             if (mLocationManager != null && mLocationProvider != null) {
                 try {
-                    return mLocationManager.getLastKnownLocation(mLocationProvider);
+                    mLocation = mLocationManager.getLastKnownLocation(mLocationProvider);
+                    return mLocation;
                 } catch (SecurityException e) {
                     Log.e(TAG, String.format("Appium Settings has no access to %s location permission",
                             mLocationProvider), e);


### PR DESCRIPTION
In "LocationTracker.java" this block of code isn't entirely accurate:

```java
//noinspection deprecation
            LocationServices.FusedLocationApi
                    .requestLocationUpdates(mGoogleApiClient, locationRequest, this);
            Log.d(TAG, "Google Play Services location provider is connected");
```

`requestLocationUpdates` returns a `PendingResult<Status>` which is asynchronous, so `Google Play Services location provider is connected` isn't true until after the `PendingResult` has resolved. 

This is a problem if `LocationServices.FusedLocationApi.getLastLocation(mGoogleApiClient);` is called _immediately_ after `requestLocationUpdates` because it won't be ready yet and it will return `null`. The logcat error is `No location to return for getLastLocation()` and calls to `/location` return errors.

This PR is a temporary stop-gap of just falling back to non-GPS location services when `getLastLocation` returns `null`. Time permitting, I would like to make a future PR that handles the `PendingResult`, but it's a bit troublesome because it's difficult to do asynchronous Java on the Android UI thread.