### PR TITLE
Start foreground service by calling proper method

### DIFF
--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -61,7 +61,7 @@ public class Settings extends Activity {
 
         // https://developer.android.com/about/versions/oreo/background-location-limits
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startService(ForegroundService.getForegroundServiceIntent(Settings.this));
+            startForegroundService(ForegroundService.getForegroundServiceIntent(Settings.this));
         }
 
         Log.d(TAG, "Closing the app");


### PR DESCRIPTION
Fixes appium/appium#13736 . Now tests on Xiaomi A1 phone start without problems.

Needs testing on other real devices.