### PR TITLE
feat: apply config.setLayoutDirection to set RTL properly for the locale

### DIFF
--- a/app/src/main/java/io/appium/settings/handlers/LocaleSettingHandler.java
+++ b/app/src/main/java/io/appium/settings/handlers/LocaleSettingHandler.java
@@ -67,6 +67,7 @@ public class LocaleSettingHandler extends AbstractSettingHandler {
         f.setBoolean(config, true);
 
         config.locale = locale;
+        config.setLayoutDirection(locale);
 
         Method methodUpdateConfiguration = activityManagerNativeClass.getMethod("updateConfiguration", Configuration.class);
         methodUpdateConfiguration.setAccessible(true);


### PR DESCRIPTION
https://github.com/appium/appium/issues/14334

https://stackoverflow.com/questions/31904627/android-change-entire-app-layout-directions-programmatically

https://github.com/mozilla-mobile/focus-android/blob/5ba3bc737e13dc359904dc639e342f397bd767a0/app/src/main/java/org/mozilla/focus/locale/LocaleManager.java#L238-L240

We already support over API Level 18
I could not find properties in `getprop` like locale if we used it as a test case..

```
kazu$ adb shell am broadcast -a io.appium.settings.locale --es lang fa --es country AF
Broadcasting: Intent { act=io.appium.settings.locale flg=0x400000 (has extras) }
Broadcast completed: result=0
kazu$ adb shell am broadcast -a io.appium.settings.locale --es lang ja --es country JP
Broadcasting: Intent { act=io.appium.settings.locale flg=0x400000 (has extras) }
Broadcast completed: result=0
```

- ja-JP
<img src='https://user-images.githubusercontent.com/5511591/81812245-d881b680-9560-11ea-943a-76d38cdb75e7.png' width=300>

- fa-AF
<img src='https://user-images.githubusercontent.com/5511591/81812257-dcadd400-9560-11ea-8094-8dda7be4e1b5.png' width=300>
