### PR TITLE
Fix crash when intent is null

### DIFF
--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -85,7 +85,6 @@ public class LocationService extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             finishForegroundSetup();
         }
-        Log.i(TAG, "INTENT " + intent.getExtras());
 
         handleIntent(intent);
 
@@ -104,6 +103,8 @@ public class LocationService extends Service {
         if (intent == null) {
             return;
         }
+        Log.i(TAG, "INTENT " + intent.getExtras());
+
         // update the locationFactory also if the service is already running to mock
         updateMockLocationFactory(intent);
         scheduleLocationUpdate();

--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -105,7 +105,7 @@ public class LocationService extends Service {
         }
         Log.i(TAG, "INTENT " + intent.getExtras());
 
-        // update the locationFactory also if the service is already running to mock
+        // update the locationFactory also if the service is already running to mock.
         updateMockLocationFactory(intent);
         scheduleLocationUpdate();
     }


### PR DESCRIPTION
Hi there, 
Somehow for location service, intent can be null, so i got null pointer exception in LocationService:88. I share logcat file with you.
[device.log](https://github.com/appium/io.appium.settings/files/5318653/device.log)
