### PR TITLE
chore: Increase geo coordinates preciseness

### DIFF
--- a/app/src/main/java/io/appium/settings/receivers/LocationInfoReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/LocationInfoReceiver.java
@@ -45,7 +45,7 @@ public class LocationInfoReceiver extends BroadcastReceiver
         if (location != null) {
             setResultCode(Activity.RESULT_OK);
             // Decimal separator is a dot
-            setResultData(String.format(Locale.US, "%.5f %.5f %.5f",
+            setResultData(String.format(Locale.US, "%.7f %.7f %.7f",
                     location.getLatitude(), location.getLongitude(), location.getAltitude()));
         } else {
             setResultCode(Activity.RESULT_CANCELED);

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
     }
 }
 


### PR DESCRIPTION
This is needed to align the output with iOS, where 7 characters after the decimal separator are returned