### PR TITLE
Location enhance

### DIFF
--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -24,6 +24,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
 
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationServices;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +51,8 @@ public class Settings extends Activity {
         setContentView(R.layout.main);
         Log.d(TAG, "Entering the app");
 
-        LocationTracker.getInstance().start(this);
+        FusedLocationProviderClient fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
+        LocationTracker.getInstance().start(this, fusedLocationClient);
 
         final List<Class<? extends BroadcastReceiver>> receiverClasses = new ArrayList<>();
         receiverClasses.add(WiFiConnectionSettingReceiver.class);


### PR DESCRIPTION
As most of the devices are in the room, if google api service could not fetch location, it may be failed in most of the times while it is trying to fetch the location from current providers.
Thus, I make some enhancements for this logic, use official task to request location intervalley.
Use both providers to fetch data more quickly (In my tests, network provider could return data)

Please help review it to see if it works for your guys, from my tests, it is working.