### PR TITLE
feat!: Added optional speed parameter for proper location mocking.

### DIFF
--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -50,6 +50,7 @@ public class LocationService extends Service {
     private static final String LONGITUDE_PARAMETER_KEY = "longitude";
     private static final String LATITUDE_PARAMETER_KEY = "latitude";
     private static final String ALTITUDE_PARAMETER_KEY = "altitude";
+    private static final String SPEED_PARAMETER_KEY = "speed";
 
     private static final long UPDATE_INTERVAL_MS = 2000L;
 
@@ -197,8 +198,17 @@ public class LocationService extends Service {
             Log.e(TAG, String.format("altitude should be a valid number. '%s' is given instead",
                     intent.getStringExtra(ALTITUDE_PARAMETER_KEY)));
         }
+        float speed = 0.0f;
+        try {
+            if (intent.hasExtra(SPEED_PARAMETER_KEY)) {
+                speed = Float.valueOf(intent.getStringExtra(SPEED_PARAMETER_KEY));
+            }
+        } catch (NumberFormatException e) {
+            Log.e(TAG, String.format("speed should be a valid number. '%s' is given instead",
+                    intent.getStringExtra(SPEED_PARAMETER_KEY)));
+        }
 
-        locationFactory.setLocation(latitude, longitude, altitude);
+        locationFactory.setLocation(latitude, longitude, altitude, speed);
     }
 
     private List<MockLocationProvider> createMockProviders(LocationManager locationManager) {

--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -198,10 +198,10 @@ public class LocationService extends Service {
             Log.e(TAG, String.format("altitude should be a valid number. '%s' is given instead",
                     intent.getStringExtra(ALTITUDE_PARAMETER_KEY)));
         }
-        float speed = 0.0f;
         try {
             if (intent.hasExtra(SPEED_PARAMETER_KEY)) {
-                speed = Float.valueOf(intent.getStringExtra(SPEED_PARAMETER_KEY));
+                float speed = Float.valueOf(intent.getStringExtra(SPEED_PARAMETER_KEY));
+
                 locationFactory.setLocation(latitude, longitude, altitude, speed);
                 return;
             }

--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -202,13 +202,15 @@ public class LocationService extends Service {
         try {
             if (intent.hasExtra(SPEED_PARAMETER_KEY)) {
                 speed = Float.valueOf(intent.getStringExtra(SPEED_PARAMETER_KEY));
+                locationFactory.setLocation(latitude, longitude, altitude, speed);
+                return;
             }
         } catch (NumberFormatException e) {
             Log.e(TAG, String.format("speed should be a valid number. '%s' is given instead",
                     intent.getStringExtra(SPEED_PARAMETER_KEY)));
         }
 
-        locationFactory.setLocation(latitude, longitude, altitude, speed);
+        locationFactory.setLocation(latitude, longitude, altitude);
     }
 
     private List<MockLocationProvider> createMockProviders(LocationManager locationManager) {

--- a/app/src/main/java/io/appium/settings/location/LocationFactory.java
+++ b/app/src/main/java/io/appium/settings/location/LocationFactory.java
@@ -26,6 +26,7 @@ public class LocationFactory {
     private double longitude;
     private double altitude;
     private float speed;
+    private boolean hasSpeed = false;
 
 
     public synchronized Location createLocation(String providerName, float accuracy) {
@@ -35,7 +36,7 @@ public class LocationFactory {
         l.setLatitude(latitude);
         l.setLongitude(longitude);
         l.setAltitude(altitude);
-        if (speed == Float.MAX_VALUE) {
+        if (hasSpeed) {
             l.setSpeed(speed);
         }
         l.setBearing(0);
@@ -48,13 +49,15 @@ public class LocationFactory {
     }
 
     public synchronized void setLocation(double latitude, double longitude, double altitude, float speed) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.altitude = altitude;
+        this.setLocation(latitude, longitude, altitude);
         this.speed = speed;
+        this.hasSpeed = true;
     }
 
     public synchronized void setLocation(double latitude, double longitude, double altitude) {
-        this.setLocation(latitude, longitude, altitude, Float.MAX_VALUE);
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.altitude = altitude;
+        this.hasSpeed = false;
     }
 }

--- a/app/src/main/java/io/appium/settings/location/LocationFactory.java
+++ b/app/src/main/java/io/appium/settings/location/LocationFactory.java
@@ -35,7 +35,9 @@ public class LocationFactory {
         l.setLatitude(latitude);
         l.setLongitude(longitude);
         l.setAltitude(altitude);
-        l.setSpeed(speed);
+        if (speed == Float.MAX_VALUE) {
+            l.setSpeed(speed);
+        }
         l.setBearing(0);
 
         l.setTime(System.currentTimeMillis());
@@ -50,5 +52,9 @@ public class LocationFactory {
         this.longitude = longitude;
         this.altitude = altitude;
         this.speed = speed;
+    }
+
+    public synchronized void setLocation(double latitude, double longitude, double altitude) {
+        this.setLocation(latitude, longitude, altitude, Float.MAX_VALUE);
     }
 }

--- a/app/src/main/java/io/appium/settings/location/LocationFactory.java
+++ b/app/src/main/java/io/appium/settings/location/LocationFactory.java
@@ -25,6 +25,7 @@ public class LocationFactory {
     private double latitude;
     private double longitude;
     private double altitude;
+    private float speed;
 
 
     public synchronized Location createLocation(String providerName, float accuracy) {
@@ -34,7 +35,7 @@ public class LocationFactory {
         l.setLatitude(latitude);
         l.setLongitude(longitude);
         l.setAltitude(altitude);
-        l.setSpeed(0);
+        l.setSpeed(speed);
         l.setBearing(0);
 
         l.setTime(System.currentTimeMillis());
@@ -44,9 +45,10 @@ public class LocationFactory {
         return l;
     }
 
-    public synchronized void setLocation(double latitude, double longitude, double altitude) {
+    public synchronized void setLocation(double latitude, double longitude, double altitude, float speed) {
         this.latitude = latitude;
         this.longitude = longitude;
         this.altitude = altitude;
+        this.speed = speed;
     }
 }


### PR DESCRIPTION
This is required in order to properly mock location updates for applications that require valid speed. 
Setting location speed to 0.0 will make the location.hasSpeed() method to wrongly report that it has valid speed even though location.speed is 0.0 and in documentation this value is considered as invalid speed. 
This was improved by enabling to set speed from exterior by sending "speed" parameter or if no speed was provided then the speed field will no longer be set making the location object to correctly report that it does not have speed. 