### PR TITLE
feat: Added optional speed parameter for proper location mocking

### DIFF
--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -50,6 +50,7 @@ public class LocationService extends Service {
     private static final String LONGITUDE_PARAMETER_KEY = "longitude";
     private static final String LATITUDE_PARAMETER_KEY = "latitude";
     private static final String ALTITUDE_PARAMETER_KEY = "altitude";
+    private static final String SPEED_PARAMETER_KEY = "speed";
 
     private static final long UPDATE_INTERVAL_MS = 2000L;
 
@@ -196,6 +197,17 @@ public class LocationService extends Service {
         } catch (NumberFormatException e) {
             Log.e(TAG, String.format("altitude should be a valid number. '%s' is given instead",
                     intent.getStringExtra(ALTITUDE_PARAMETER_KEY)));
+        }
+        try {
+            if (intent.hasExtra(SPEED_PARAMETER_KEY)) {
+                float speed = Float.valueOf(intent.getStringExtra(SPEED_PARAMETER_KEY));
+
+                locationFactory.setLocation(latitude, longitude, altitude, speed);
+                return;
+            }
+        } catch (NumberFormatException e) {
+            Log.e(TAG, String.format("speed should be a valid number larger then 0.0. '%s' is given instead",
+                    intent.getStringExtra(SPEED_PARAMETER_KEY)));
         }
 
         locationFactory.setLocation(latitude, longitude, altitude);

--- a/app/src/main/java/io/appium/settings/location/LocationFactory.java
+++ b/app/src/main/java/io/appium/settings/location/LocationFactory.java
@@ -25,6 +25,8 @@ public class LocationFactory {
     private double latitude;
     private double longitude;
     private double altitude;
+    private float speed;
+    private boolean hasSpeed = false;
 
 
     public synchronized Location createLocation(String providerName, float accuracy) {
@@ -34,7 +36,9 @@ public class LocationFactory {
         l.setLatitude(latitude);
         l.setLongitude(longitude);
         l.setAltitude(altitude);
-        l.setSpeed(0);
+        if (hasSpeed) {
+            l.setSpeed(speed);
+        }
         l.setBearing(0);
 
         l.setTime(System.currentTimeMillis());
@@ -44,9 +48,16 @@ public class LocationFactory {
         return l;
     }
 
+    public synchronized void setLocation(double latitude, double longitude, double altitude, float speed) {
+        this.setLocation(latitude, longitude, altitude);
+        this.speed = speed;
+        this.hasSpeed = true;
+    }
+
     public synchronized void setLocation(double latitude, double longitude, double altitude) {
         this.latitude = latitude;
         this.longitude = longitude;
         this.altitude = altitude;
+        this.hasSpeed = false;
     }
 }


### PR DESCRIPTION
This is required in order to properly mock location updates for applications that require valid speed.
Setting location speed to 0.0 will make the location.hasSpeed() method to wrongly report that it has valid speed even though location.speed is 0.0 and in documentation this value is considered as invalid speed.
This was improved by enabling to set speed from exterior by sending "speed" parameter or if no speed was provided then the speed field will no longer be set making the location object to correctly report that it does not have speed.

This is related to:
- **python-client** pull request: https://github.com/appium/python-client/pull/594
- **appium-adb** pull request https://github.com/appium/appium-adb/pull/563