### PR TITLE
fix: refer to mavenCentral instead of jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.3'
@@ -12,6 +12,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }


### PR DESCRIPTION
fix https://github.com/appium/io.appium.settings/issues/68

```
% npm install      

> io.appium.settings@4.0.2 prepare
> npm run build


> io.appium.settings@4.0.2 build
> ./gradlew clean assembleDebug && npm run move-apks


> Task :app:compileDebugJavaWithJavac
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

BUILD SUCCESSFUL in 37s
27 actionable tasks: 27 executed

> io.appium.settings@4.0.2 move-apks
> rm -rf apks && mkdir -p apks && cp app/build/outputs/apk/debug/settings_apk-debug.apk apks


up to date, audited 1560 packages in 46s

115 packages are looking for funding
  run `npm fund` for details

29 vulnerabilities (13 moderate, 14 high, 2 critical)
```

I remember this repo still referred to jcenter.