### PR TITLE
fix: Implement locale validation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-location:19.0.0'
+    implementation 'com.google.android.gms:play-services-location:19.0.1'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 static def renameAPK(variant) {

--- a/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
@@ -68,7 +68,7 @@ public class LocaleSettingReceiver extends BroadcastReceiver implements HasActio
                     locale, LocaleUtils.availableLocaleList())
             );
             setResultCode(Activity.RESULT_CANCELED);
-            setResultData("");
+            setResultData(String.format("The locale %s is not known", locale));
             return;
         }
 

--- a/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
@@ -16,10 +16,15 @@
 
 package io.appium.settings.receivers;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+
+import org.apache.commons.lang3.LocaleUtils;
 
 import java.util.Locale;
 
@@ -37,40 +42,40 @@ public class LocaleSettingReceiver extends BroadcastReceiver implements HasActio
     // am broadcast -a io.appium.settings.locale --es lang ja --es country JP
     @Override
     public void onReceive(Context context, Intent intent) {
-        if(!hasExtraLocale(intent)) {
-            Log.e(TAG, "Don't forget to set lang and country like: am broadcast -a io.appium.settings.locale --es lang ja --es country JP");
-            Log.e(TAG, "Set en-US by default.");
-
-            intent.putExtra(LANG, "en");
-            intent.putExtra(COUNTRY, "US");
-        }
-
         String language = intent.getStringExtra(LANG);
         String country = intent.getStringExtra(COUNTRY);
-
+        if (language == null || country == null) {
+            Log.w(TAG, "It is required to provide both language and country, for example: " +
+                    "am broadcast -a io.appium.settings.locale --es lang ja --es country JP");
+            Log.i(TAG, "Set en-US by default.");
+            language = "en";
+            country= "US";
+        }
         // Expect https://developer.android.com/reference/java/util/Locale.html#Locale(java.lang.String,%20java.lang.String) format.
         Locale locale = new Locale(language, country);
-
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-            String script = intent.getStringExtra(SCRIPT);
-
-            Locale.Builder builder = new Locale.Builder();
-            builder.setLocale(locale);
-            builder.setScript(script == null ? "" : script); // "Hans" part
-            locale = builder.build();
-            // "zh-Hans-CN" or "zh-CN" format
-            Log.i(TAG, "Set language tag: " + locale.toLanguageTag());
-        } else {
-            Log.i(TAG, "Set locale: " + locale.toString());
+        String script = intent.getStringExtra(SCRIPT);
+        if (!isBlank(script)) {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                locale = new Locale.Builder().setLocale(locale).setScript(script).build();
+            } else {
+                Log.w(TAG, String.format("Script value '%s' is ignored as " +
+                        "setting of it is not supported by the current Android version", script));
+            }
+        }
+        if (!LocaleUtils.isAvailableLocale(locale)) {
+            Log.e(TAG, String.format(
+                    "The locale %s is not known. Only the following locales are available: %s",
+                    locale, LocaleUtils.availableLocaleList())
+            );
+            setResultCode(Activity.RESULT_CANCELED);
+            setResultData("");
+            return;
         }
 
-        LocaleSettingHandler localeSettingHandler = new LocaleSettingHandler(context);
-
-        localeSettingHandler.setLocale(locale);
-    }
-
-    private boolean hasExtraLocale(Intent intent) {
-        return intent.hasExtra(LANG) && intent.hasExtra(COUNTRY);
+        new LocaleSettingHandler(context).setLocale(locale);
+        Log.i(TAG, String.format("Set locale: %s", locale));
+        setResultCode(Activity.RESULT_OK);
+        setResultData(locale.toString());
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.2.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip


### PR DESCRIPTION
The way locale is set is hacky and since the built-in Locale class does not have any validation of the provided locale parameters we could potentially brick the device. This change adds basic validation of known locale names and avoids the private API to be called if the locale name is not known.