### PR TITLE
chore: Reduce the finish activity delay to zero

### DIFF
--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -206,7 +206,7 @@ public class Settings extends Activity {
     private void finishActivity() {
         Log.d(TAG, "Closing the app");
         Handler handler = new Handler();
-        handler.postDelayed(Settings.this::finish, 1000);
+        handler.postDelayed(Settings.this::finish, 0);
     }
 
     @Override


### PR DESCRIPTION
I don't see an actual need to wait for 1 second until the activity is closed. Also, this creates an unnecessary video frames where a white screen is shown for media projection recordings