### PR TITLE
ci: use node 16, cleanup a bit

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
@@ -23,8 +23,6 @@ jobs:
         cache: gradle
     - run: npm install --no-package-lock
       name: Install dependencies
-    - run: npm test
-      name: Run NPM Test
     - run: npx semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This repository does not upload npm modules, so devDependencies won't be in the package.
Also this repo has no tests via npm run test, so we can remove it from the push task.