### PR TITLE
chore: Exclude sources from the published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,7 @@
   ],
   "files": [
     "index.js",
-    "gradle*",
-    "build.gradle",
-    "settings.gradle",
-    "apks/",
-    "app/build.gradle",
-    "app/src/",
-    "gradle/",
+    "apks",
     "!.DS_Store",
     "NOTICE.txt"
   ],


### PR DESCRIPTION
I don't see much point into having sources in the published package. It only takes extra space and slows down the deployment