### PR TITLE
chore: add changelog plugin to generate it automatically

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,11 +4,17 @@
       "preset": "angular",
       "releaseRules": [
         {"type": "chore", "release": "patch"}
-        
+
       ]
     }],
-    "@semantic-release/npm",
     "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/npm",
     ["@semantic-release/git", {
       "assets": ["docs", "package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/.releaserc
+++ b/.releaserc
@@ -16,7 +16,7 @@
     ],
     "@semantic-release/npm",
     ["@semantic-release/git", {
-      "assets": ["docs", "package.json"],
+      "assets": ["docs", "package.json", "CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     ["@semantic-release/github", {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "index.js",
     "apks",
     "!.DS_Store",
-    "NOTICE.txt"
+    "NOTICE.txt",
+    "CHANGELOG.md"
   ],
   "author": "Appium Contributors",
   "license": "Apache-2.0",


### PR DESCRIPTION
Current out release task only generates changelos in https://github.com/appium/io.appium.settings/releases, but it would be helpful to prepare a file which has changelos in it.

https://github.com/semantic-release/changelog#examples also recommend to tweak the order, so this PR follows the recommendation a bit.

Expected behavior by this is:

- CHANGELOG.md in the top will have all changelog (or newer than this version)
- the npm package will have it

If this works well, I'd like to add the same one in other drivers so that users can track changelogs with this generator (without our work to collect changes in one changelog)