### PR TITLE
ci: remove Upload Release Asse

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -32,12 +32,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Release
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./apks/settings_apk-debug.apk
-        asset_name: my-settings_apk-debug.apk
-        asset_content_type: application/zip


### PR DESCRIPTION
The action project is already archived. I thought I already removed that, but still exist. Let's remove the unused one