### PR TITLE
chore: fix the installation error in the @semantic-release/changelog

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -8,12 +8,9 @@
       ]
     }],
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
+    ["@semantic-release/changelog", {
         "changelogFile": "CHANGELOG.md"
-      }
-    ],
+    }],
     "@semantic-release/npm",
     ["@semantic-release/git", {
       "assets": ["docs", "package.json", "CHANGELOG.md"],

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^7.32.0",
     "fancy-log": "^2.0.0",
     "@semantic-release/git": "^10.0.1",
+    "@semantic-release/changelog": "^6.0.1",
     "semantic-release": "^19.0.2",
     "semver": "^7.3.7"
   }


### PR DESCRIPTION
no module error occurred. Let me add the plugin via package.json as same as the git one