### PR TITLE
Revert "chore(deps-dev): bump semantic-release from 19.0.5 to 20.0.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/changelog": "^6.0.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
-    "semantic-release": "^20.0.2",
+    "semantic-release": "^19.0.2",
     "semver": "^7.3.7"
   }
 }


### PR DESCRIPTION
Reverts appium/io.appium.settings#102

> node-versions: node v18 is now the minimum required version of node. this is in line with our [node support policy](https://semantic-release.gitbook.io/semantic-release/support/node-support-policy). please see [our recommendations](https://semantic-release.gitbook.io/semantic-release/support/node-version#recommended-solution) for releasing with a different node version than your project normally uses, if necessary.

Noticed this point. Maybe we should add the build nodejs version update in the same change, so lets revert the change for now