### PR TITLE
fix: Prevent Appium IME from sending extraneous onKeyUp events

### DIFF
--- a/app/src/main/java/io/appium/settings/AppiumIME.java
+++ b/app/src/main/java/io/appium/settings/AppiumIME.java
@@ -109,6 +109,12 @@ public class AppiumIME extends InputMethodService {
         Log.i(TAG, String.format("onKeyUp (keyCode='%s', event.keyCode='%s', metaState='%s')",
                 keyCode, event.getKeyCode(), event.getMetaState()));
         metaState = MetaKeyKeyListener.handleKeyUp(metaState, keyCode, event);
+
+        final int c = getUnicodeChar(keyCode, event);
+        if (isEnteringActionName || c == ACTION_FLAG_KEY) {
+            return true;
+        }
+
         return super.onKeyUp(keyCode, event);
     }
 


### PR DESCRIPTION
Appium IME receives editor action commands by intercepting `onKeyDown` events, but it does not intercept the corresponding `onKeyUp` events. This results in extraneous `onKeyUp` events being sent to the application when performing editor actions through Appium.

This PR modifies the `onKeyUp` handler to suppress key up events while processing editor action commands, similarly to `onKeyDown`.

<details>
<summary>Test script</summary>

This script opens a key event test page and performs an editor action. Without the patch, extraneous key up events for the command string `/send/` will be visible on the page.

```
import time
from appium import webdriver

desired_caps = {
    'platformName': 'Android',
    'deviceName': 'Android Emulator',
    'browserName': 'Chrome',
    'automationName': 'UiAutomator2'
}

driver = webdriver.Remote('http://localhost:4723', desired_caps)

# Navigate to the test page and send action
driver.get('https://unixpapa.com/js/testkey.html')
driver.execute_script('mobile: performEditorAction', {'action': 'send'})

time.sleep(10)
driver.quit()
```
</details>
