### PR TITLE
feat: add option to ignore locale verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,14 @@ $ adb shell am broadcast -a io.appium.settings.animation --es setstatus disable
 Set particular locale:
 
 ```shell
+# If not granted already, grant locale change permission https://developer.android.com/reference/android/Manifest.permission#CHANGE_CONFIGURATION
+$ adb shell pm grant io.appium.settings android.permission.CHANGE_CONFIGURATION
 $ adb shell am broadcast -a io.appium.settings.locale -n io.appium.settings/.receivers.LocaleSettingReceiver --es lang ja --es country JP
 $ adb shell getprop persist.sys.locale # ja-JP
 $ adb shell am broadcast -a io.appium.settings.locale -n io.appium.settings/.receivers.LocaleSettingReceiver --es lang zh --es country CN --es script Hans
 $ adb shell getprop persist.sys.locale # zh-Hans-CN for API level 21+
+# When 'skip_locale_check' parameter is set appium settings application doesn't check that locale you are trying to set is a valid locale string, by default it validates the locale and throws error when invalid 
+$ adb shell am broadcast -a io.appium.settings.locale -n io.appium.settings/.receivers.LocaleSettingReceiver --es lang xx --es country US --es skip_locale_check 1
 ```
 
 You can set the [Locale](https://developer.android.com/reference/java/util/Locale.html) format, especially this feature support [Locale(String language, String country)](https://developer.android.com/reference/java/util/Locale.html#Locale(java.lang.String,%20java.lang.String)) so far.

--- a/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
+++ b/app/src/main/java/io/appium/settings/receivers/LocaleSettingReceiver.java
@@ -37,6 +37,7 @@ public class LocaleSettingReceiver extends BroadcastReceiver implements HasActio
 
     private static final String LANG = "lang";
     private static final String COUNTRY = "country";
+    private static final String SKIP_LOCALE_CHECK = "skip_locale_check";
     private static final String SCRIPT = "script";
 
     private static final String ACTION = "io.appium.settings.locale";
@@ -46,6 +47,7 @@ public class LocaleSettingReceiver extends BroadcastReceiver implements HasActio
     public void onReceive(Context context, Intent intent) {
         String language = intent.getStringExtra(LANG);
         String country = intent.getStringExtra(COUNTRY);
+        String skipLocaleCheck = intent.getStringExtra(SKIP_LOCALE_CHECK);
         if (language == null || country == null) {
             Log.w(TAG, "It is required to provide both language and country, for example: " +
                     "am broadcast -a io.appium.settings.locale --es lang ja --es country JP");
@@ -55,11 +57,15 @@ public class LocaleSettingReceiver extends BroadcastReceiver implements HasActio
         }
         // Expect https://developer.android.com/reference/java/util/Locale.html#Locale(java.lang.String,%20java.lang.String) format.
         Locale locale = new Locale(language, country);
+        Log.i(TAG, String.format("Obtained locale: %s", locale));
         String script = intent.getStringExtra(SCRIPT);
         if (script != null) {
             locale = new Locale.Builder().setLocale(locale).setScript(script).build();
         }
-        if (!LocaleUtils.isAvailableLocale(locale)) {
+        if (skipLocaleCheck != null) {
+            Log.i(TAG, "'skip_locale_check' value is provided, will not check locale availability");
+        }
+        else if (!LocaleUtils.isAvailableLocale(locale)) {
             List<Locale> approximateMatchesLc = matchLocales(language, country);
             if (!approximateMatchesLc.isEmpty() && isBlank(script)) {
                 Log.i(TAG, String.format(


### PR DESCRIPTION
This PR provides the ability to change language locale to an unidentified language.

For us when we set a locale(unidentified by the Android OS) but a custom locale name(understood by the Android application) the app instead of showing the text, shows an ID which is mapped to a language translation database. This helps us to check whether the textual elements on the screen are mapped to the correct translation ID for each language the app supports.




This is how the Appium settings app behaves for unidentified locale without this PR's change
```bash
$ adb shell am broadcast -a io.appium.settings.locale -n io.appium.settings/.receivers.LocaleSettingReceiver --es lang xx --es country US
Broadcasting: Intent { act=io.appium.settings.locale flg=0x400000 cmp=io.appium.settings/.receivers.LocaleSettingReceiver (has extras) }
Broadcast completed: result=0, data="The locale xx_US is not known"

# check locale
$ adb shell getprop | grep locale
[persist.sys.locale]: [en-US]
[ro.product.locale]: [en-US]
```

With This PR change
```bash
$ adb shell am broadcast -a io.appium.settings.locale -n io.appium.settings/.receivers.LocaleSettingReceiver --es lang xx --es country US --es skip_locale_check 1
Broadcasting: Intent { act=io.appium.settings.locale flg=0x400000 cmp=io.appium.settings/.receivers.LocaleSettingReceiver (has extras) }
Broadcast completed: result=-1, data="xx_US"

# check local
$ adb shell getprop | grep locale
[persist.sys.locale]: [xx-US]
[ro.product.locale]: [en-US]
```

Adb log
```bash
07-25 17:07:11.677   572  1892 I ActivityManager: Broadcasting: Intent { act=io.appium.settings.locale flg=0x400000 cmp=io.appium.settings/.receivers.LocaleSettingReceiver (has extras) }
07-25 17:07:11.680   572  1892 I ActivityManager: Enqueued broadcast Intent { act=io.appium.settings.locale flg=0x400000 cmp=io.appium.settings/.receivers.LocaleSettingReceiver (has extras) }: 0
07-25 17:07:11.685   572   616 W ProcessStats: Tracking association SourceState{9bc167c com.google.android.googlequicksearchbox:search/10123 Service #42184} whose proc state 8 is better than process ProcessState{e26e2ee com.google.android.gms/10121 pkg=com.google.android.gms} proc state 13 (7 skipped)
07-25 17:07:11.692  7546  7546 I LocaleSettingReceiver: Obtained locale: xx_US
07-25 17:07:11.692  7546  7546 I LocaleSettingReceiver: 'skip_locale_check' value is provided, will not check locale availability
07-25 17:07:11.698  7546  7546 W appium.settings: Accessing hidden method Landroid/app/ActivityManagerNative;->getDefault()Landroid/app/IActivityManager; (unsupported, reflection, allowed)
07-25 17:07:11.699  7546  7546 W appium.settings: Accessing hidden method Landroid/app/IActivityManager$Stub$Proxy;->getConfiguration()Landroid/content/res/Configuration; (unsupported, reflection, allowed)
07-25 17:07:11.702  7546  7546 W appium.settings: Accessing hidden field Landroid/content/res/Configuration;->userSetLocale:Z (unsupported, reflection, allowed)
07-25 17:07:11.706  7546  7546 W appium.settings: Accessing hidden method Landroid/app/IActivityManager$Stub$Proxy;->updateConfiguration(Landroid/content/res/Configuration;)Z (max-target-o, reflection, denied)
07-25 17:07:11.706  7546  7546 W appium.settings: Accessing hidden method Landroid/app/IActivityManager;->updateConfiguration(Landroid/content/res/Configuration;)Z (max-target-r, reflection, allowed)
07-25 17:07:11.709  7546  7546 I LocaleSettingReceiver: Set locale: xx_US
07-25 17:07:11.714   572   604 I ActivityManager: Broadcast completed: result=-1, data="xx_US"
```
<img width="317" alt="image" src="https://github.com/appium/io.appium.settings/assets/6311526/e39c65b7-72e3-43f8-8532-10d5dd2ef001">





