### PR TITLE
feat: Add EmptyIME

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,21 @@
         </service>
 
         <service
+            android:name=".EmptyIME"
+            android:label="Empty IME"
+            android:enabled="true"
+            android:permission="android.permission.BIND_INPUT_METHOD"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method" />
+        </service>
+
+        <service
             android:name=".UnicodeIME"
             android:label="Unicode IME"
             android:enabled="true"

--- a/app/src/main/java/io/appium/settings/EmptyIME.java
+++ b/app/src/main/java/io/appium/settings/EmptyIME.java
@@ -1,0 +1,33 @@
+/*
+ *    Copyright 2013 TOYAMA Sumio <jun.nama@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.settings;
+
+import android.annotation.SuppressLint;
+import android.inputmethodservice.InputMethodService;
+
+public class EmptyIME extends InputMethodService {
+    @Override
+    public boolean onEvaluateFullscreenMode() {
+        return false;
+    }
+
+    @SuppressLint("MissingSuperCall")
+    @Override
+    public boolean onEvaluateInputViewShown() {
+        return false;
+    }
+}


### PR DESCRIPTION
It is convenient to not have keyboard popping up in order to run various tests. `EmptyIME` does exactly that - it allows input without showing the on-screen keyboard.