### PR TITLE
feat: use play services location 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ option would have no effect.
 ## Setting Mock Locations
 
 Please set the Appium Settings from the Settings app's _Developer Options_ -> _Select mock location app_. 
+Or `adb shell appops set io.appium.settings android:mock_location allow` let you do the same via adb command.
+`adb shell appops set io.appium.settings android:mock_location deny` is to turn it off.
+
 
 Start sending scheduled updates (every 2s) for mock location with the specified values by executing:
 (API versions 26+):

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ option would have no effect.
 
 ## Setting Mock Locations
 
+Please set the Appium Settings from the Settings app's _Developer Options_ -> _Select mock location app_. 
+
 Start sending scheduled updates (every 2s) for mock location with the specified values by executing:
 (API versions 26+):
 ```shell

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-location:19.0.1'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation 'org.apache.commons:commons-lang3:3.13.0'
 }
 
 static def renameAPK(variant) {

--- a/app/src/main/java/io/appium/settings/LocationTracker.java
+++ b/app/src/main/java/io/appium/settings/LocationTracker.java
@@ -174,9 +174,6 @@ public class LocationTracker implements LocationListener {
 
         Log.d(TAG, "Stopping Google Play Services location provider");
         mFusedLocationProviderClient.removeLocationUpdates(locationCallback);
-        if (mFusedLocationProviderClient.asGoogleApiClient().isConnected()) {
-            mFusedLocationProviderClient.asGoogleApiClient().disconnect();
-        }
         mFusedLocationProviderClient = null;
     }
 

--- a/app/src/main/java/io/appium/settings/location/FusedLocationProvider.java
+++ b/app/src/main/java/io/appium/settings/location/FusedLocationProvider.java
@@ -54,10 +54,6 @@ public class FusedLocationProvider implements MockLocationProvider {
         if (!hasPermissions()) {
             return;
         }
-        if (!fusedLocationProviderClient.asGoogleApiClient().isConnected()) {
-            Log.d(TAG, "GoogleApiClient is not connected");
-            return;
-        }
         fusedLocationProviderClient.setMockLocation(location);
     }
 
@@ -67,7 +63,6 @@ public class FusedLocationProvider implements MockLocationProvider {
         if (!hasPermissions()) {
             return;
         }
-        fusedLocationProviderClient.asGoogleApiClient().connect();
         fusedLocationProviderClient.setMockMode(true);
     }
 
@@ -78,7 +73,6 @@ public class FusedLocationProvider implements MockLocationProvider {
             return;
         }
         fusedLocationProviderClient.setMockMode(false);
-        fusedLocationProviderClient.asGoogleApiClient().disconnect();
     }
 
     @Override


### PR DESCRIPTION
With the latest location service, `asGoogleApiClient` was removed.


According to the https://developers.google.com/android/guides/api-client 

> These objects automatically manage the connection to Google Play services. When a connection is available, each API client object executes requests in order. Otherwise, the client object queues the requests

So... maybe we no longer need them...?

I have tested below command worked expectedly with Google map on a real device.

> adb shell am start-foreground-service --user 0 -n io.appium.settings/.LocationService --es longitude "10.0000" --es latitude "10.0000"
>  adb shell am stopservice io.appium.settings/.LocationService

I have installed the settings app with `-g` option.


---

Let me ask https://github.com/appium/appium/issues/19238 if this helps for other env...