### PR TITLE
feat: Add javascript wrappers over Settings App APIs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+coverage
+build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Linter
-        run: |
-          npm run js:lint
-          npm run lint
+        run: npm run lint
       - name: Build
         run: npm run build

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,36 @@
+name: Unit Tests
+
+on: [pull_request, push]
+
+
+jobs:
+  prepare_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.generate-matrix.outputs.versions }}
+    steps:
+    - name: Select 3 most recent LTS versions of Node.js
+      id: generate-matrix
+      run: echo "versions=$(curl -s https://endoflife.date/api/nodejs.json | jq -c '[[.[] | select(.lts != false)][:3] | .[].cycle | tonumber]')" >> "$GITHUB_OUTPUT"
+
+
+  test:
+    needs:
+    - prepare_matrix
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(needs.prepare_matrix.outputs.versions) }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install --no-package-lock
+      name: Install dev dependencies
+    - run: npm run build
+      name: Build
+    - run: npm run js:lint
+      name: Run linter
+    - run: npm run js:test
+      name: Run unit tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,6 +26,11 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Use Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
     - run: npm install --no-package-lock
       name: Install dev dependencies
     - run: npm run build

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  require: ['ts-node/register'],
+  forbidOnly: Boolean(process.env.CI),
+  color: true
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
-const path = require('path');
+const path = require('node:path');
+const { SettingsApp } = require('./build/lib/client');
+const constants = require('./build/lib/constants');
 
 module.exports = {
-  path: path.resolve(__dirname, 'apks', 'settings_apk-debug.apk')
+  path: path.resolve(__dirname, 'apks', 'settings_apk-debug.apk'),
+  SettingsApp,
+  ...constants,
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -49,7 +49,7 @@ export class SettingsApp {
    * @throws {Error} If Appium Settings has failed to start
    * @returns {Promise<SettingsApp>} self instance for chaining
    */
-  async requireRunningSettingsApp (opts = {}) {
+  async requireRunning (opts = {}) {
     if (await this.adb.processExists(SETTINGS_HELPER_ID)) {
       return this;
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,0 +1,155 @@
+import { log, LOG_PREFIX } from './logger';
+import _ from 'lodash';
+import { waitForCondition } from 'asyncbox';
+import { SETTINGS_HELPER_ID, SETTINGS_HELPER_MAIN_ACTIVITY } from './constants.js';
+import { setAnimationState } from './commands/animation';
+import { getClipboard } from './commands/clipboard';
+import { setGeoLocation, getGeoLocation, refreshGeoLocationCache } from './commands/geolocation';
+import { setDeviceSysLocale } from './commands/locale';
+import { scanMedia } from './commands/media';
+import { setDataState, setWifiState } from './commands/network';
+import { getNotifications } from './commands/notifications';
+import { getSmsList } from './commands/sms';
+import { performEditorAction, typeUnicode } from './commands/typing';
+
+/**
+ * @typedef {Object} SettingsAppOpts
+ * @property {import('appium-adb').ADB} adb
+ */
+
+
+export class SettingsApp {
+  /** @type {import('appium-adb').ADB} */
+  adb;
+
+  /** @type {import('npmlog').Logger} */
+  log;
+
+  /**
+   * @param {SettingsAppOpts} opts
+   */
+  constructor (opts) {
+    this.adb = opts.adb;
+    this.log = log;
+  }
+
+  /**
+   * @typedef {Object} SettingsAppStartupOptions
+   * @property {number} [timeout=5000] The maximum number of milliseconds
+   * to wait until the app has started
+   * @property {boolean} [shouldRestoreCurrentApp=false] Whether to restore
+   * the activity which was the current one before Settings startup
+   */
+
+  /**
+   * Ensures that Appium Settings helper application is running
+   * and starts it if necessary
+   *
+   * @param {SettingsAppStartupOptions} [opts={}]
+   * @throws {Error} If Appium Settings has failed to start
+   * @returns {Promise<SettingsApp>} self instance for chaining
+   */
+  async requireRunningSettingsApp (opts = {}) {
+    if (await this.adb.processExists(SETTINGS_HELPER_ID)) {
+      return this;
+    }
+
+    this.log.debug(LOG_PREFIX, 'Starting Appium Settings app');
+    const {
+      timeout = 5000,
+      shouldRestoreCurrentApp = false,
+    } = opts;
+    let appPackage;
+    if (shouldRestoreCurrentApp) {
+      try {
+        ({appPackage} = await this.adb.getFocusedPackageAndActivity());
+      } catch (e) {
+        this.log.warn(LOG_PREFIX, `The current application can not be restored: ${e.message}`);
+      }
+    }
+    await this.adb.startApp({
+      pkg: SETTINGS_HELPER_ID,
+      activity: SETTINGS_HELPER_MAIN_ACTIVITY,
+      action: 'android.intent.action.MAIN',
+      category: 'android.intent.category.LAUNCHER',
+      stopApp: false,
+      waitForLaunch: false,
+    });
+    try {
+      await waitForCondition(async () => await this.adb.processExists(SETTINGS_HELPER_ID), {
+        waitMs: timeout,
+        intervalMs: 300,
+      });
+      if (shouldRestoreCurrentApp && appPackage) {
+        try {
+          await this.adb.activateApp(appPackage);
+        } catch (e) {
+          log.warn(`The current application can not be restored: ${e.message}`);
+        }
+      }
+      return this;
+    } catch (err) {
+      throw new Error(`Appium Settings app is not running after ${timeout}ms`);
+    }
+  }
+
+  /**
+   * Parses the output in JSON format retrieved from
+   * the corresponding Appium Settings broadcast calls
+   *
+   * @param {string} output The actual command output
+   * @param {string} entityName The name of the entity which is
+   * going to be parsed
+   * @returns {Object} The parsed JSON object
+   * @throws {Error} If the output cannot be parsed
+   * as a valid JSON
+   */
+  _parseJsonData (output, entityName) {
+    if (!/\bresult=-1\b/.test(output) || !/\bdata="/.test(output)) {
+      this.log.debug(LOG_PREFIX, output);
+      throw new Error(
+        `Cannot retrieve ${entityName} from the device. ` +
+        'Check the server log for more details'
+      );
+    }
+    const match = /\bdata="(.+)",?/.exec(output);
+    if (!match) {
+      this.log.debug(LOG_PREFIX, output);
+      throw new Error(
+        `Cannot parse ${entityName} from the command output. ` +
+        'Check the server log for more details'
+      );
+    }
+    const jsonStr = _.trim(match[1]);
+    try {
+      return JSON.parse(jsonStr);
+    } catch (e) {
+      log.debug(jsonStr);
+      throw new Error(
+        `Cannot parse ${entityName} from the resulting data string. ` +
+        'Check the server log for more details'
+      );
+    }
+  }
+
+  setAnimationState = setAnimationState;
+
+  getClipboard = getClipboard;
+
+  setGeoLocation = setGeoLocation;
+  getGeoLocation = getGeoLocation;
+  refreshGeoLocationCache = refreshGeoLocationCache;
+
+  setDeviceSysLocale = setDeviceSysLocale;
+
+  scanMedia = scanMedia;
+
+  setDataState = setDataState;
+  setWifiState = setWifiState;
+
+  getNotifications = getNotifications;
+  getSmsList = getSmsList;
+
+  performEditorAction = performEditorAction;
+  typeUnicode = typeUnicode;
+}

--- a/lib/commands/animation.js
+++ b/lib/commands/animation.js
@@ -1,0 +1,24 @@
+import { ANIMATION_SETTING_ACTION, ANIMATION_SETTING_RECEIVER } from '../constants.js';
+
+/**
+ * Change the state of animation on the device under test.
+ * Animation on the device is controlled by the following global properties:
+ * [ANIMATOR_DURATION_SCALE]{@link https://developer.android.com/reference/android/provider/Settings.Global.html#ANIMATOR_DURATION_SCALE},
+ * [TRANSITION_ANIMATION_SCALE]{@link https://developer.android.com/reference/android/provider/Settings.Global.html#TRANSITION_ANIMATION_SCALE},
+ * [WINDOW_ANIMATION_SCALE]{@link https://developer.android.com/reference/android/provider/Settings.Global.html#WINDOW_ANIMATION_SCALE}.
+ * This method sets all this properties to 0.0 to disable (1.0 to enable) animation.
+ *
+ * Turning off animation might be useful to improve stability
+ * and reduce tests execution time.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {boolean} on - True to enable and false to disable it.
+ */
+export async function setAnimationState (on) {
+  await this.adb.shell([
+    'am', 'broadcast',
+    '-a', ANIMATION_SETTING_ACTION,
+    '-n', ANIMATION_SETTING_RECEIVER,
+    '--es', 'setstatus', on ? 'enable' : 'disable'
+  ]);
+};

--- a/lib/commands/clipboard.js
+++ b/lib/commands/clipboard.js
@@ -1,0 +1,47 @@
+import _ from 'lodash';
+import { LOG_PREFIX } from '../logger';
+import {
+  CLIPBOARD_RECEIVER,
+  CLIPBOARD_RETRIEVAL_ACTION,
+  APPIUM_IME
+} from '../constants';
+
+/**
+ * Retrieves the text content of the device's clipboard.
+ * The method works for Android below and above 29.
+ * It temorarily enforces the IME setting in order to workaround
+ * security limitations if needed.
+ * This method only works if Appium Settings v. 2.15+ is installed
+ * on the device under test
+ *
+ * @this {import('../client').SettingsApp}
+ * @returns {Promise<string>} The actual content of the main clipboard as
+ * base64-encoded string or an empty string if the clipboard is empty
+ * @throws {Error} If there was a problem while getting the
+ * clipboard contant
+ */
+export async function getClipboard () {
+  this.log.debug(LOG_PREFIX, 'Getting the clipboard content');
+  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  const retrieveClipboard = async () => await this.adb.shell([
+    'am', 'broadcast',
+    '-n', CLIPBOARD_RECEIVER,
+    '-a', CLIPBOARD_RETRIEVAL_ACTION,
+  ]);
+  let output;
+  try {
+    output = (await this.adb.getApiLevel() >= 29)
+      ? (await this.adb.runInImeContext(APPIUM_IME, retrieveClipboard))
+      : (await retrieveClipboard());
+  } catch (err) {
+    throw new Error(`Cannot retrieve the current clipboard content from the device. ` +
+      `Make sure the Appium Settings application is up to date. ` +
+      `Original error: ${err.message}`);
+  }
+
+  const match = /data="([^"]*)"/.exec(output);
+  if (!match) {
+    throw new Error(`Cannot parse the actual cliboard content from the command output: ${output}`);
+  }
+  return _.trim(match[1]);
+};

--- a/lib/commands/clipboard.js
+++ b/lib/commands/clipboard.js
@@ -22,7 +22,7 @@ import {
  */
 export async function getClipboard () {
   this.log.debug(LOG_PREFIX, 'Getting the clipboard content');
-  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  await this.requireRunning({shouldRestoreCurrentApp: true});
   const retrieveClipboard = async () => await this.adb.shell([
     'am', 'broadcast',
     '-n', CLIPBOARD_RECEIVER,

--- a/lib/commands/geolocation.js
+++ b/lib/commands/geolocation.js
@@ -1,0 +1,214 @@
+import _ from 'lodash';
+import {
+  LOCATION_SERVICE,
+  LOCATION_RECEIVER,
+  LOCATION_RETRIEVAL_ACTION,
+} from '../constants.js';
+import { SubProcess } from 'teen_process';
+import B from 'bluebird';
+import { LOG_PREFIX } from '../logger.js';
+
+const DEFAULT_SATELLITES_COUNT = 12;
+const DEFAULT_ALTITUDE = 0.0;
+const LOCATION_TRACKER_TAG = 'LocationTracker';
+const GPS_CACHE_REFRESHED_LOGS = [
+  'The current location has been successfully retrieved from Play Services',
+  'The current location has been successfully retrieved from Location Manager'
+];
+
+const GPS_COORDINATES_PATTERN = /data="(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)"/;
+
+/**
+ * @typedef {Object} Location
+ * @property {number|string} longitude - Valid longitude value.
+ * @property {number|string} latitude - Valid latitude value.
+ * @property {?number|string} [altitude] - Valid altitude value.
+ * @property {?number|string} [satellites=12] - Number of satellites being tracked (1-12).
+ * This value is ignored on real devices.
+ * @property {?number|string} [speed] - Valid speed value.
+ * Should be greater than 0.0 meters/second for real devices or 0.0 knots
+ * for emulators.
+ */
+
+/**
+ * Emulate geolocation coordinates on the device under test.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {Location} location - Location object. The `altitude` value is ignored
+ * while mocking the position.
+ * @param {boolean} [isEmulator=false] - Set it to true if the device under test
+ *                                       is an emulator rather than a real device.
+ */
+export async function setGeoLocation (location, isEmulator = false) {
+  const formatLocationValue = (valueName, isRequired = true) => {
+    if (_.isNil(location[valueName])) {
+      if (isRequired) {
+        throw new Error(`${valueName} must be provided`);
+      }
+      return null;
+    }
+    const floatValue = parseFloat(location[valueName]);
+    if (!isNaN(floatValue)) {
+      return `${_.ceil(floatValue, 5)}`;
+    }
+    if (isRequired) {
+      throw new Error(`${valueName} is expected to be a valid float number. ` +
+        `'${location[valueName]}' is given instead`);
+    }
+    return null;
+  };
+  const longitude = /** @type {string} */ (formatLocationValue('longitude'));
+  const latitude = /** @type {string} */ (formatLocationValue('latitude'));
+  const altitude = formatLocationValue('altitude', false);
+  const speed = formatLocationValue('speed', false);
+  if (isEmulator) {
+    /** @type {string[]} */
+    const args = [longitude, latitude];
+    if (!_.isNil(altitude)) {
+      args.push(altitude);
+    }
+    const satellites = parseInt(`${location.satellites}`, 10);
+    if (!Number.isNaN(satellites) && satellites > 0 && satellites <= 12) {
+      if (args.length < 3) {
+        args.push(`${DEFAULT_ALTITUDE}`);
+      }
+      args.push(`${satellites}`);
+    }
+    if (!_.isNil(speed)) {
+      if (args.length < 3) {
+        args.push(`${DEFAULT_ALTITUDE}`);
+      }
+      if (args.length < 4) {
+        args.push(`${DEFAULT_SATELLITES_COUNT}`);
+      }
+      args.push(speed);
+    }
+    await this.adb.resetTelnetAuthToken();
+    await this.adb.adbExec(['emu', 'geo', 'fix', ...args]);
+    // A workaround for https://code.google.com/p/android/issues/detail?id=206180
+    await this.adb.adbExec(['emu', 'geo', 'fix', ...(args.map((arg) => arg.replace('.', ',')))]);
+  } else {
+    const args = [
+      'am', (await this.adb.getApiLevel() >= 26) ? 'start-foreground-service' : 'startservice',
+      '-e', 'longitude', longitude,
+      '-e', 'latitude', latitude,
+    ];
+    if (!_.isNil(altitude)) {
+      args.push('-e', 'altitude', altitude);
+    }
+    if (!_.isNil(speed)) {
+      args.push('-e', 'speed', speed);
+    }
+    args.push(LOCATION_SERVICE);
+    await this.adb.shell(args);
+  }
+};
+
+/**
+ * Get the current cached GPS location from the device under test.
+ *
+ * @this {import('../client').SettingsApp}
+ * @returns {Promise<Location>} The current location
+ * @throws {Error} If the current location cannot be retrieved
+ */
+export async function getGeoLocation () {
+  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+
+  let output;
+  try {
+    output = await this.adb.shell([
+      'am', 'broadcast',
+      '-n', LOCATION_RECEIVER,
+      '-a', LOCATION_RETRIEVAL_ACTION,
+    ]);
+  } catch (err) {
+    throw new Error(`Cannot retrieve the current geo coordinates from the device. ` +
+      `Make sure the Appium Settings application is up to date and has location permissions. Also the location ` +
+      `services must be enabled on the device. Original error: ${err.stderr || err.stdout || err.message}`);
+  }
+
+  const match = GPS_COORDINATES_PATTERN.exec(output);
+  if (!match) {
+    throw new Error(`Cannot parse the actual location values from the command output: ${output}`);
+  }
+  const location = {
+    latitude: match[1],
+    longitude: match[2],
+    altitude: match[3],
+  };
+  this.log.debug(LOG_PREFIX, `Got geo coordinates: ${JSON.stringify(location)}`);
+  return location;
+};
+
+/**
+ * Sends an async request to refresh the GPS cache.
+ * This feature only works if the device under test has
+ * Google Play Services installed. In case the vanilla
+ * LocationManager is used the device API level must be at
+ * version 30 (Android R) or higher.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {number} timeoutMs The maximum number of milliseconds
+ * to block until GPS cache is refreshed. Providing zero or a negative
+ * value to it skips waiting completely.
+ *
+ * @throws {Error} If the GPS cache cannot be refreshed.
+ */
+export async function refreshGeoLocationCache (timeoutMs = 20000) {
+  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+
+  let logcatMonitor;
+  let monitoringPromise;
+
+  if (timeoutMs > 0) {
+    const cmd = [
+      ...this.adb.executable.defaultArgs,
+      'logcat', '-s', LOCATION_TRACKER_TAG,
+    ];
+    logcatMonitor = new SubProcess(this.adb.executable.path, cmd);
+    const timeoutErrorMsg = `The GPS cache has not been refreshed within ${timeoutMs}ms timeout. ` +
+      `Please make sure the device under test has Appium Settings app installed and running. ` +
+      `Also, it is required that the device has Google Play Services installed or is running ` +
+      `Android 10+ otherwise.`;
+    monitoringPromise = new B((resolve, reject) => {
+      setTimeout(() => reject(new Error(timeoutErrorMsg)), timeoutMs);
+
+      logcatMonitor.on('exit', () => reject(new Error(timeoutErrorMsg)));
+      ['lines-stderr', 'lines-stdout'].map((evt) => logcatMonitor.on(evt, (lines) => {
+        if (lines.some((line) => GPS_CACHE_REFRESHED_LOGS.some((x) => line.includes(x)))) {
+          resolve();
+        }
+      }));
+    });
+    await logcatMonitor.start(0);
+  }
+
+  try {
+    await this.adb.shell([
+      'am', 'broadcast',
+      '-n', LOCATION_RECEIVER,
+      '-a', LOCATION_RETRIEVAL_ACTION,
+      '--ez', 'forceUpdate', 'true',
+    ]);
+  } catch (err) {
+    throw new Error(`Cannot refresh the GPS cache on the device. ` +
+      `Make sure the Appium Settings application is up to date and has location permissions. Also the location ` +
+      `services must be enabled on the device. Original error: ${err.stderr || err.stdout || err.message}`);
+  }
+
+  if (logcatMonitor && monitoringPromise) {
+    const startMs = performance.now();
+    this.log.debug(LOG_PREFIX, `Waiting up to ${timeoutMs}ms for the GPS cache to be refreshed`);
+    try {
+      await monitoringPromise;
+      this.log.info(LOG_PREFIX, `The GPS cache has been successfully refreshed after ` +
+        `${(performance.now() - startMs).toFixed(0)}ms`);
+    } finally {
+      if (logcatMonitor.isRunning) {
+        await logcatMonitor.stop();
+      }
+    }
+  } else {
+    this.log.info(LOG_PREFIX, 'The request to refresh the GPS cache has been sent. Skipping waiting for its result.');
+  }
+};

--- a/lib/commands/geolocation.js
+++ b/lib/commands/geolocation.js
@@ -112,7 +112,7 @@ export async function setGeoLocation (location, isEmulator = false) {
  * @throws {Error} If the current location cannot be retrieved
  */
 export async function getGeoLocation () {
-  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  await this.requireRunning({shouldRestoreCurrentApp: true});
 
   let output;
   try {
@@ -155,7 +155,7 @@ export async function getGeoLocation () {
  * @throws {Error} If the GPS cache cannot be refreshed.
  */
 export async function refreshGeoLocationCache (timeoutMs = 20000) {
-  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  await this.requireRunning({shouldRestoreCurrentApp: true});
 
   let logcatMonitor;
   let monitoringPromise;

--- a/lib/commands/locale.js
+++ b/lib/commands/locale.js
@@ -1,0 +1,28 @@
+import { LOCALE_SETTING_ACTION, LOCALE_SETTING_RECEIVER } from '../constants.js';
+
+/**
+ * Change the locale on the device under test. Don't need to reboot the device after changing the locale.
+ * This method sets an arbitrary locale following:
+ *   https://developer.android.com/reference/java/util/Locale.html
+ *   https://developer.android.com/reference/java/util/Locale.html#Locale(java.lang.String,%20java.lang.String)
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {string} language - Language. e.g. en, ja
+ * @param {string} country - Country. e.g. US, JP
+ * @param {string?} [script=null] - Script. e.g. Hans in `zh-Hans-CN`
+ */
+export async function setDeviceSysLocale (language, country, script = null) {
+  const params = [
+    'am', 'broadcast',
+    '-a', LOCALE_SETTING_ACTION,
+    '-n', LOCALE_SETTING_RECEIVER,
+    '--es', 'lang', language.toLowerCase(),
+    '--es', 'country', country.toUpperCase()
+  ];
+
+  if (script) {
+    params.push('--es', 'script', script);
+  }
+
+  await this.adb.shell(params);
+};

--- a/lib/commands/media.js
+++ b/lib/commands/media.js
@@ -13,7 +13,7 @@ import { MEDIA_SCAN_ACTION, MEDIA_SCAN_RECEIVER } from '../constants.js';
  */
 export async function scanMedia (destination) {
   this.log.debug(LOG_PREFIX, `Scanning '${destination}' for media files`);
-  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  await this.requireRunning({shouldRestoreCurrentApp: true});
   const output = await this.adb.shell([
     'am', 'broadcast',
     '-n', MEDIA_SCAN_RECEIVER,

--- a/lib/commands/media.js
+++ b/lib/commands/media.js
@@ -1,0 +1,27 @@
+import _ from 'lodash';
+import { LOG_PREFIX } from '../logger.js';
+import { MEDIA_SCAN_ACTION, MEDIA_SCAN_RECEIVER } from '../constants.js';
+
+/**
+ * Performs recursive media scan at the given destination.
+ * All successfully scanned items are being added to the device's
+ * media library.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {string} destination File/folder path on the remote device.
+ * @throws {Error} If there was an unexpected error by scanning.
+ */
+export async function scanMedia (destination) {
+  this.log.debug(LOG_PREFIX, `Scanning '${destination}' for media files`);
+  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  const output = await this.adb.shell([
+    'am', 'broadcast',
+    '-n', MEDIA_SCAN_RECEIVER,
+    '-a', MEDIA_SCAN_ACTION,
+    '--es', 'path', destination
+  ]);
+  if (!_.includes(output, 'result=-1')) {
+    throw new Error(`No media could be scanned at '${destination}'. ` +
+      `Check the device logcat output for more details.`);
+  }
+};

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -1,0 +1,73 @@
+import {
+  WIFI_CONNECTION_SETTING_ACTION,
+  WIFI_CONNECTION_SETTING_RECEIVER,
+  DATA_CONNECTION_SETTING_ACTION,
+  DATA_CONNECTION_SETTING_RECEIVER,
+} from '../constants.js';
+
+/**
+ * Change the state of WiFi on the device under test.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {boolean} on - True to enable and false to disable it.
+ * @param {boolean} [isEmulator=false] - Set it to true if the device under test
+ *                                       is an emulator rather than a real device.
+ */
+export async function setWifiState (on, isEmulator = false) {
+  if (isEmulator) {
+    // The svc command does not require to be root since API 26
+    await this.adb.shell(['svc', 'wifi', on ? 'enable' : 'disable'], {
+      privileged: await this.adb.getApiLevel() < 26,
+    });
+    return;
+  }
+
+  if (await this.adb.getApiLevel() < 30) {
+    // Android below API 30 does not have a dedicated adb command
+    // to manipulate wifi connection state, so try to do it via Settings app
+    // as a workaround
+    await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+
+    await this.adb.shell([
+      'am', 'broadcast',
+      '-a', WIFI_CONNECTION_SETTING_ACTION,
+      '-n', WIFI_CONNECTION_SETTING_RECEIVER,
+      '--es', 'setstatus', on ? 'enable' : 'disable'
+    ]);
+    return;
+  }
+
+  await this.adb.shell(['cmd', '-w', 'wifi', 'set-wifi-enabled', on ? 'enabled' : 'disabled']);
+};
+
+/**
+ * Change the state of Data transfer on the device under test.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {boolean} on - True to enable and false to disable it.
+ * @param {boolean} [isEmulator=false] - Set it to true if the device under test
+ *                                       is an emulator rather than a real device.
+ */
+export async function setDataState (on, isEmulator = false) {
+  if (isEmulator) {
+    // The svc command does not require to be root since API 26
+    await this.adb.shell(['svc', 'data', on ? 'enable' : 'disable'], {
+      privileged: await this.adb.getApiLevel() < 26,
+    });
+    return;
+  }
+
+  if (await this.adb.getApiLevel() < 30) {
+    await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+
+    await this.adb.shell([
+      'am', 'broadcast',
+      '-a', DATA_CONNECTION_SETTING_ACTION,
+      '-n', DATA_CONNECTION_SETTING_RECEIVER,
+      '--es', 'setstatus', on ? 'enable' : 'disable'
+    ]);
+    return;
+  }
+
+  await this.adb.shell(['cmd', 'phone', 'data', on ? 'enable' : 'disable']);
+};

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -26,7 +26,7 @@ export async function setWifiState (on, isEmulator = false) {
     // Android below API 30 does not have a dedicated adb command
     // to manipulate wifi connection state, so try to do it via Settings app
     // as a workaround
-    await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+    await this.requireRunning({shouldRestoreCurrentApp: true});
 
     await this.adb.shell([
       'am', 'broadcast',
@@ -58,7 +58,7 @@ export async function setDataState (on, isEmulator = false) {
   }
 
   if (await this.adb.getApiLevel() < 30) {
-    await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+    await this.requireRunning({shouldRestoreCurrentApp: true});
 
     await this.adb.shell([
       'am', 'broadcast',

--- a/lib/commands/notifications.js
+++ b/lib/commands/notifications.js
@@ -55,7 +55,7 @@ export async function getNotifications () {
   // renders the broadcast to fail instead of starting the
   // Appium Settings app. This only happens to the notifications
   // receiver
-  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  await this.requireRunning({shouldRestoreCurrentApp: true});
   let output;
   try {
     output = await this.adb.shell([

--- a/lib/commands/notifications.js
+++ b/lib/commands/notifications.js
@@ -1,0 +1,71 @@
+import { LOG_PREFIX } from '../logger';
+import { NOTIFICATIONS_RETRIEVAL_ACTION } from '../constants';
+
+/**
+ * Retrieves Android notifications via Appium Settings helper.
+ * Appium Settings app itself must be *manually* granted to access notifications
+ * under device Settings in order to make this feature working.
+ * Appium Settings helper keeps all the active notifications plus
+ * notifications that appeared while it was running in the internal buffer,
+ * but no more than 100 items altogether. Newly appeared notifications
+ * are always added to the head of the notifications array.
+ * The `isRemoved` flag is set to `true` for notifications that have been removed.
+ *
+ * See https://developer.android.com/reference/android/service/notification/StatusBarNotification
+ * and https://developer.android.com/reference/android/app/Notification.html
+ * for more information on available notification properties and their values.
+ *
+ * @this {import('../client').SettingsApp}
+ * @returns {Promise<Record<string, any>>} The example output is:
+ * ```json
+ * {
+ *   "statusBarNotifications":[
+ *     {
+ *       "isGroup":false,
+ *       "packageName":"io.appium.settings",
+ *       "isClearable":false,
+ *       "isOngoing":true,
+ *       "id":1,
+ *       "tag":null,
+ *       "notification":{
+ *         "title":null,
+ *         "bigTitle":"Appium Settings",
+ *         "text":null,
+ *         "bigText":"Keep this service running, so Appium for Android can properly interact with several system APIs",
+ *         "tickerText":null,
+ *         "subText":null,
+ *         "infoText":null,
+ *         "template":"android.app.Notification$BigTextStyle"
+ *       },
+ *       "userHandle":0,
+ *       "groupKey":"0|io.appium.settings|1|null|10133",
+ *       "overrideGroupKey":null,
+ *       "postTime":1576853518850,
+ *       "key":"0|io.appium.settings|1|null|10133",
+ *       "isRemoved":false
+ *     }
+ *   ]
+ * }
+ * ```
+ * @throws {Error} If there was an error while getting the notifications list
+ */
+export async function getNotifications () {
+  this.log.debug(LOG_PREFIX, 'Retrieving notifications');
+  // Somehow providing the `-n` arg to the `am` underneath
+  // renders the broadcast to fail instead of starting the
+  // Appium Settings app. This only happens to the notifications
+  // receiver
+  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  let output;
+  try {
+    output = await this.adb.shell([
+      'am', 'broadcast',
+      '-a', NOTIFICATIONS_RETRIEVAL_ACTION,
+    ]);
+  } catch (err) {
+    throw new Error(`Cannot retrieve notifications from the device. ` +
+      `Make sure the Appium Settings application is installed and is up to date. ` +
+      `Original error: ${err.message}`);
+  }
+  return this._parseJsonData(output, 'notifications');
+};

--- a/lib/commands/sms.js
+++ b/lib/commands/sms.js
@@ -71,7 +71,7 @@ import { SMS_LIST_RECEIVER, SMS_LIST_RETRIEVAL_ACTION } from '../constants.js';
  */
 export async function getSmsList (opts = {}) {
   this.log.debug(LOG_PREFIX, 'Retrieving the recent SMS messages');
-  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  await this.requireRunning({shouldRestoreCurrentApp: true});
   const args = [
     'am', 'broadcast',
     '-n', SMS_LIST_RECEIVER,

--- a/lib/commands/sms.js
+++ b/lib/commands/sms.js
@@ -1,0 +1,92 @@
+import { LOG_PREFIX } from '../logger.js';
+import { SMS_LIST_RECEIVER, SMS_LIST_RETRIEVAL_ACTION } from '../constants.js';
+
+/**
+ * @typedef {Object} SmsListOptions
+ * @property {number} [max=100] - The maximum count of recent messages
+ * to retrieve
+ */
+
+/**
+ * @typedef SmsListResult
+ * @property {SmsListResultItem[]} items
+ * @property {number} total
+ */
+
+/**
+ * @privateRemarks XXX: WAG
+ * @typedef SmsListResultItem
+ * @property {string} id
+ * @property {string} address
+ * @property {string|null} person
+ * @property {string} date
+ * @property {string} read
+ * @property {string} status
+ * @property {string} type
+ * @property {string|null} subject
+ * @property {string} body
+ * @property {string|null} serviceCenter
+ */
+
+/**
+ * Retrieves the list of the most recent SMS
+ * properties list via Appium Settings helper.
+ * Messages are sorted by date in descending order.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {SmsListOptions} opts
+ * @returns {Promise<SmsListResult>} The example output is:
+ * ```json
+ * {
+ *   "items":[
+ *     {
+ *       "id":"2",
+ *       "address":"+123456789",
+ *       "person":null,
+ *       "date":"1581936422203",
+ *       "read":"0",
+ *       "status":"-1",
+ *       "type":"1",
+ *       "subject":null,
+ *       "body":"\"text message2\"",
+ *       "serviceCenter":null
+ *     },
+ *     {
+ *       "id":"1",
+ *       "address":"+123456789",
+ *       "person":null,
+ *       "date":"1581936382740",
+ *       "read":"0",
+ *       "status":"-1",
+ *       "type":"1",
+ *       "subject":null,
+ *       "body":"\"text message\"",
+ *       "serviceCenter":null
+ *     }
+ *   ],
+ *   "total":2
+ * }
+ * ```
+ * @throws {Error} If there was an error while getting the SMS list
+ */
+export async function getSmsList (opts = {}) {
+  this.log.debug(LOG_PREFIX, 'Retrieving the recent SMS messages');
+  await this.requireRunningSettingsApp({shouldRestoreCurrentApp: true});
+  const args = [
+    'am', 'broadcast',
+    '-n', SMS_LIST_RECEIVER,
+    '-a', SMS_LIST_RETRIEVAL_ACTION,
+  ];
+  if (opts.max) {
+    args.push('--es', 'max', `${opts.max}`);
+  }
+  let output;
+  try {
+    output = await this.adb.shell(args);
+  } catch (err) {
+    throw new Error(`Cannot retrieve SMS list from the device. ` +
+      `Make sure the Appium Settings application is installed and is up to date. ` +
+      `Original error: ${err.message}`);
+  }
+  return this._parseJsonData(output, 'SMS list');
+};

--- a/lib/commands/typing.js
+++ b/lib/commands/typing.js
@@ -1,0 +1,46 @@
+import _ from 'lodash';
+import { APPIUM_IME, UNICODE_IME } from '../constants.js';
+import { imap } from './utf7';
+import { LOG_PREFIX } from '../logger.js';
+
+/**
+ * Performs the given editor action on the focused input field.
+ * This method requires Appium Settings helper to be installed on the device.
+ * No exception is thrown if there was a failure while performing the action.
+ * You must investigate the logcat output if something did not work as expected.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {string|number} action - Either action code or name. The following action
+ *                                 names are supported: `normal, unspecified, none,
+ *                                 go, search, send, next, done, previous`
+ */
+export async function performEditorAction (action) {
+  this.log.debug(LOG_PREFIX, `Performing editor action: ${action}`);
+  await this.adb.runInImeContext(APPIUM_IME,
+    async () => await this.adb.shell(['input', 'text', `/${action}/`]));
+};
+
+/**
+ * Types the given Unicode string.
+ * It is expected that the focus is already put
+ * to the destination input field before this method is called.
+ *
+ * @this {import('../client').SettingsApp}
+ * @param {string} text The string to type
+ * @returns {Promise<boolean>} `true` if the input text has been successfully sent to adb
+ */
+export async function typeUnicode (text) {
+  if (_.isNil(text)) {
+    return false;
+  }
+
+  text = `${text}`;
+  this.log.debug(LOG_PREFIX, `Typing ${text.length} character${text.length === 1 ? '' : 's'}`);
+  if (!text) {
+    return false;
+  }
+  await this.adb.runInImeContext(
+    UNICODE_IME, async () => await this.adb.inputText(imap.encode(text))
+  );
+  return true;
+};

--- a/lib/commands/utf7.js
+++ b/lib/commands/utf7.js
@@ -1,0 +1,154 @@
+/*
+ * The code below has been adopted from https://www.npmjs.com/package/utf7
+ */
+
+/**
+ * @param {number} length
+ * @returns {Buffer}
+ */
+function allocateAsciiBuffer(length) {
+  return Buffer.alloc(length, 'ascii');
+}
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function _encode(str) {
+  const b = allocateAsciiBuffer(str.length * 2);
+  for (let i = 0, bi = 0; i < str.length; i++) {
+    // Note that we can't simply convert a UTF-8 string to Base64 because
+    // UTF-8 uses a different encoding. In modified UTF-7, all characters
+    // are represented by their two byte Unicode ID.
+    const c = str.charCodeAt(i);
+    // Upper 8 bits shifted into lower 8 bits so that they fit into 1 byte.
+    b[bi++] = c >> 8;
+    // Lower 8 bits. Cut off the upper 8 bits so that they fit into 1 byte.
+    b[bi++] = c & 0xFF;
+  }
+  // Modified Base64 uses , instead of / and omits trailing =.
+  return b.toString('base64').replace(/=+$/, '');
+}
+
+/**
+ * @param {string} str
+ * @returns {Buffer}
+ */
+function allocateBase64Buffer(str) {
+  return Buffer.from(str, 'base64');
+}
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function _decode(str) {
+  const b = allocateBase64Buffer(str);
+  const r = [];
+  for (let i = 0; i < b.length;) {
+    // Calculate charcode from two adjacent bytes.
+    r.push(String.fromCharCode(b[i++] << 8 | b[i++]));
+  }
+  return r.join('');
+}
+
+/**
+ * Escape RegEx from http://simonwillison.net/2006/Jan/20/escape/
+ *
+ * @param {string} chars
+ * @returns {string}
+ */
+function escape(chars) {
+  return chars.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
+// Character classes defined by RFC 2152.
+const setD = 'A-Za-z0-9' + escape(`'(),-./:?`);
+const setO = escape(`!"#$%&*;<=>@[]^_'{|}`);
+const setW = escape(` \r\n\t`);
+
+// Stores compiled regexes for various replacement pattern.
+/** @type {Record<string, RegExp>} */
+const regexes = {};
+const regexAll = new RegExp(`[^${setW}${setD}${setO}]+`, 'g');
+
+export const imap = {};
+
+/**
+ * RFC 2152 UTF-7 encoding.
+ *
+ * @param {string} str
+ * @param {string?} mask
+ * @returns {string}
+ */
+export const encode = function encode(str, mask = null) {
+  // Generate a RegExp object from the string of mask characters.
+  if (!mask) {
+    mask = '';
+  }
+  if (!regexes[mask]) {
+    regexes[mask] = new RegExp(`[^${setD}${escape(mask)}]+`, 'g');
+  }
+
+  // We replace subsequent disallowed chars with their escape sequence.
+  return str.replace(regexes[mask], (chunk) =>
+    // + is represented by an empty sequence +-, otherwise call encode().
+    `+${chunk === '+' ? '' : _encode(chunk)}-`
+  );
+};
+
+/**
+ * RFC 2152 UTF-7 encoding with all optionals.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+export function encodeAll(str) {
+  // We replace subsequent disallowed chars with their escape sequence.
+  return str.replace(regexAll, (chunk) =>
+    // + is represented by an empty sequence +-, otherwise call encode().
+    `+${chunk === '+' ? '' : _encode(chunk)}-`
+  );
+};
+
+/**
+ * RFC 3501, section 5.1.3 UTF-7 encoding.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+imap.encode = function encode(str) {
+  // All printable ASCII chars except for & must be represented by themselves.
+  // We replace subsequent non-representable chars with their escape sequence.
+  return str.replace(/&/g, '&-').replace(/[^\x20-\x7e]+/g, (chunk) => {
+    // & is represented by an empty sequence &-, otherwise call encode().
+    chunk = (chunk === '&' ? '' : _encode(chunk)).replace(/\//g, ',');
+    return `&${chunk}-`;
+  });
+};
+
+/**
+ * RFC 2152 UTF-7 decoding.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+export const decode = function decode(str) {
+  return str.replace(/\+([A-Za-z0-9/]*)-?/gi, (_, chunk) =>
+    // &- represents &.
+    chunk === '' ? '+' : _decode(chunk)
+  );
+};
+
+/**
+ * RFC 3501, section 5.1.3 UTF-7 decoding.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+imap.decode = function decode(str) {
+  return str.replace(/&([^-]*)-/g, (_, chunk) =>
+    // &- represents &.
+    chunk === '' ? '&' : _decode(chunk.replace(/,/g, '/'))
+  );
+};

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,31 @@
+export const SETTINGS_HELPER_ID = 'io.appium.settings';
+export const SETTINGS_HELPER_MAIN_ACTIVITY = '.Settings';
+
+export const CLIPBOARD_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.ClipboardReceiver`;
+export const CLIPBOARD_RETRIEVAL_ACTION = `${SETTINGS_HELPER_ID}.clipboard.get`;
+
+export const APPIUM_IME = `${SETTINGS_HELPER_ID}/.AppiumIME`;
+export const UNICODE_IME = `${SETTINGS_HELPER_ID}/.UnicodeIME`;
+
+export const WIFI_CONNECTION_SETTING_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.WiFiConnectionSettingReceiver`;
+export const WIFI_CONNECTION_SETTING_ACTION = `${SETTINGS_HELPER_ID}.wifi`;
+export const DATA_CONNECTION_SETTING_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.DataConnectionSettingReceiver`;
+export const DATA_CONNECTION_SETTING_ACTION = `${SETTINGS_HELPER_ID}.data_connection`;
+
+export const ANIMATION_SETTING_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.AnimationSettingReceiver`;
+export const ANIMATION_SETTING_ACTION = `${SETTINGS_HELPER_ID}.animation`;
+
+export const LOCALE_SETTING_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.LocaleSettingReceiver`;
+export const LOCALE_SETTING_ACTION = `${SETTINGS_HELPER_ID}.locale`;
+
+export const LOCATION_SERVICE = `${SETTINGS_HELPER_ID}/.LocationService`;
+export const LOCATION_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.LocationInfoReceiver`;
+export const LOCATION_RETRIEVAL_ACTION = `${SETTINGS_HELPER_ID}.location`;
+
+export const NOTIFICATIONS_RETRIEVAL_ACTION = `${SETTINGS_HELPER_ID}.notifications`;
+
+export const SMS_LIST_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.SmsReader`;
+export const SMS_LIST_RETRIEVAL_ACTION = `${SETTINGS_HELPER_ID}.sms.read`;
+
+export const MEDIA_SCAN_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.MediaScannerReceiver`;
+export const MEDIA_SCAN_ACTION = `${SETTINGS_HELPER_ID}.scan_media`;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,14 @@
+import npmlog from 'npmlog';
+
+
+export const LOG_PREFIX = 'SettingsApp';
+
+function getLogger () {
+  const logger = global._global_npmlog || npmlog;
+  if (!logger.debug) {
+    logger.addLevel('debug', 1000, { fg: 'blue', bg: 'black' }, 'dbug');
+  }
+  return logger;
+}
+
+export const log = getLogger();

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "js:lint": "eslint .",
     "js:lint:fix": "npm run lint -- --fix",
     "move-apks": "rm -rf apks && mkdir -p apks && cp app/build/outputs/apk/debug/settings_apk-debug.apk apks",
-    "build": "./gradlew clean assembleDebug && npm run move-apks",
+    "build": "tsc -b && ./gradlew clean assembleDebug && npm run move-apks",
     "prepare": "npm run build",
     "version": "npm run bump-gradle-version && npm run build",
-    "clean": "rm -rf node_modules && rm -f package-lock.json && npm install"
+    "clean": "npm run build -- --clean",
+    "js:test": "mocha --exit --timeout 1m \"./test/unit/**/*-specs.js\""
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,8 @@
   ],
   "files": [
     "index.js",
+    "lib",
+    "build/lib",
     "apks",
     "!.DS_Store",
     "NOTICE.txt",
@@ -40,14 +43,46 @@
     "url": "https://github.com/appium/io.appium.settings/issues"
   },
   "homepage": "https://github.com/appium/io.appium.settings",
+  "dependencies": {
+    "asyncbox": "^3.0.0",
+    "bluebird": "^3.5.1",
+    "lodash": "^4.2.1",
+    "npmlog": "^7.0.1",
+    "source-map-support": "^0.x",
+    "teen_process": "^2.0.0"
+  },
   "devDependencies": {
-    "@appium/eslint-config-appium": "^6.0.0",
-    "eslint": "^7.32.0",
-    "fancy-log": "^2.0.0",
-    "@semantic-release/git": "^10.0.1",
+    "@appium/eslint-config-appium": "^8.0.4",
+    "@appium/eslint-config-appium-ts": "^0.x",
+    "@appium/tsconfig": "^0.x",
+    "@appium/types": "^0.x",
     "@semantic-release/changelog": "^6.0.1",
+    "@semantic-release/git": "^10.0.1",
+    "@types/bluebird": "^3.5.38",
+    "@types/chai": "^4.3.5",
+    "@types/chai-as-promised": "^7.1.5",
+    "@types/lodash": "^4.14.196",
+    "@types/node": "^20.4.7",
+    "@types/teen_process": "^2.0.2",
+    "@typescript-eslint/eslint-plugin": "^6.9.0",
+    "@typescript-eslint/parser": "^6.9.0",
+    "appium-adb": "^11.0.0",
+    "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "conventional-changelog-conventionalcommits": "^7.0.1",
+    "eslint": "^8.46.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.5.5",
+    "eslint-plugin-import": "^2.28.0",
+    "eslint-plugin-mocha": "^10.1.0",
+    "eslint-plugin-promise": "^6.1.1",
+    "lint-staged": "^15.0.2",
+    "mocha": "^10.0.0",
+    "pre-commit": "^1.1.3",
+    "prettier": "^3.0.0",
     "semantic-release": "^22.0.5",
-    "semver": "^7.3.7"
+    "sinon": "^17.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6"
   }
 }

--- a/test/unit/json-parsing-specs.js
+++ b/test/unit/json-parsing-specs.js
@@ -1,0 +1,42 @@
+import chai from 'chai';
+import { SettingsApp } from '../../lib/client';
+
+const should = chai.should();
+
+
+describe('parseJsonData', function () {
+  const client = new SettingsApp({});
+
+  it('should parse JSON received from broadcast output', function () {
+    const broadcastOutput = `
+    Broadcasting: Intent { act=io.appium.settings.sms.read flg=0x400000 (has extras) }
+    Broadcast completed: result=-1, data="{"items":[{"id":"2","address":"+123456789","date":"1581936422203","read":"0","status":"-1","type":"1","body":"\\"text message2\\""},{"id":"1","address":"+123456789","date":"1581936382740","read":"0","status":"-1","type":"1","body":"\\"text message\\""}],"total":2}"
+    `;
+    const {items, total} = client._parseJsonData(broadcastOutput, '');
+    items.length.should.eql(2);
+    total.should.eql(2);
+  });
+  it('should parse JSON received from broadcast output having extras', function () {
+    const broadcastOutput = `
+    Broadcasting: Intent { act=io.appium.settings.sms.read flg=0x400000 (has extras) }
+    Broadcast completed: result=-1, data="{"items":[{"id":"2","address":"+123456789","date":"1581936422203","read":"0","status":"-1","type":"1","body":"\\"text message2\\""},{"id":"1","address":"+123456789","date":"1581936382740","read":"0","status":"-1","type":"1","body":"\\"text message\\""}],"total":2}", extras: Bundle[mParcelledData.dataSize=52]
+    `;
+    const {items, total} = client._parseJsonData(broadcastOutput, '');
+    items.length.should.eql(2);
+    total.should.eql(2);
+  });
+  it('should throw an error if json retrieval fails', function () {
+    const broadcastOutput = `
+    Broadcasting: Intent { act=io.appium.settings.sms.read flg=0x400000 (has extras) }
+    Broadcast completed: result=0, data="{"items":[{"id":"2","address":"+123456789","date":"1581936422203","read":"0","status":"-1","type":"1","body":"\\"text message2\\""},{"id":"1","address":"+123456789","date":"1581936382740","read":"0","status":"-1","type":"1","body":"\\"text message\\""}],"total":2}"
+    `;
+    should.throw(() => client._parseJsonData(broadcastOutput, ''));
+  });
+  it('should throw an error if json parsing fails', function () {
+    const broadcastOutput = `
+    Broadcasting: Intent { act=io.appium.settings.sms.read flg=0x400000 (has extras) }
+    Broadcast completed: result=-1, data="{24324"
+    `;
+    should.throw(() => client._parseJsonData(broadcastOutput, ''));
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@appium/tsconfig/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+    "checkJs": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "strict": false
+  },
+  "include": ["lib"]
+}


### PR DESCRIPTION
The next step would be to switch clients to use calls from this module rather than appium-adb.
Eventually the duplicated stuff will be deprecated and cut-off from the latter, so this module would be the only owner of the functionality related to it.