### PR TITLE
fix: Revert "chore(deps-dev): bump conventional-changelog-conventionalcommits from 7.0.2 to 8.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "appium-adb": "^12.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "conventional-changelog-conventionalcommits": "^8.0.0",
+    "conventional-changelog-conventionalcommits": "^7.0.1",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-import-resolver-typescript": "^3.5.5",


### PR DESCRIPTION
Reverts appium/io.appium.settings#164