### PR TITLE
chore: Enable BuildConfig generation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,9 @@ android {
     }
 
     namespace "io.appium.settings"
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,5 @@
 #Fri Dec 17 09:25:55 CET 2021
 android.useAndroidX=true
 android.enableJetifier=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
Enable BuildConfig generation in module-level build.gradle
this property is deprecated in Android Gradle Plugin (AGP) 8.0 and is scheduled to be removed in AGP 9.0.