### PR TITLE
fix: log argument

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -136,7 +136,7 @@ export class SettingsApp {
       ...args,
     ]);
     if (!output.includes('result=-1')) {
-      this.log.debug(output);
+      this.log.debug(LOG_PREFIX, output);
       throw new Error(`Cannot execute the '${action}' action. Check the logcat output for more details.`);
     }
     return output;


### PR DESCRIPTION
```
lib/client.js:139:16 - error TS2555: Expected at least 2 arguments, but got 1.

139       this.log.debug(output);
                   ~~~~~

  node_modules/@appium/logger/build/lib/types.d.ts:28:27
    28     debug(prefix: string, message: any, ...args: any[]): void;
                                 ~~~~~~~~~~~~
    An argument for 'message' was not provided.
```