### PR TITLE
fix: Stop media projection when stopping recording

### DIFF
--- a/app/src/main/java/io/appium/settings/recorder/RecorderThread.java
+++ b/app/src/main/java/io/appium/settings/recorder/RecorderThread.java
@@ -446,6 +446,7 @@ public class RecorderThread implements Runnable {
                 audioEncoder.release();
                 audioEncoder = null;
             }
+            mediaProjection.stop();
         }
     }
 }


### PR DESCRIPTION
### Context 

Running long and/or large test suites with screen recording for each test sometimes fails on screen recording start/stop: the media projection used for screen recording is never stopped, so after running for about an hour, the appium settings app must be killed before the screen recording starts working again. 

This can also be reproduced by running a single test with screen recoding, then leaving the device idle for a while (notice that screen recording status bar icon never disappears) and then running the test again.

### Fix
Call `mediaProjection.stop()` when screen recording is stopped. This makes sure that system resources are released and media projection is properly cleaned up.