### PR TITLE
fix: Do not register the broad cast receivers for record action

### DIFF
--- a/app/src/main/java/io/appium/settings/ForegroundService.java
+++ b/app/src/main/java/io/appium/settings/ForegroundService.java
@@ -17,17 +17,38 @@
 package io.appium.settings;
 
 import android.app.Service;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.IBinder;
 import android.util.Log;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import io.appium.settings.helpers.NotificationHelpers;
+import io.appium.settings.receivers.AnimationSettingReceiver;
+import io.appium.settings.receivers.BluetoothConnectionSettingReceiver;
+import io.appium.settings.receivers.ClipboardReceiver;
+import io.appium.settings.receivers.DataConnectionSettingReceiver;
+import io.appium.settings.receivers.HasAction;
+import io.appium.settings.receivers.LocaleSettingReceiver;
+import io.appium.settings.receivers.LocalesReader;
+import io.appium.settings.receivers.LocationInfoReceiver;
+import io.appium.settings.receivers.MediaScannerReceiver;
+import io.appium.settings.receivers.NotificationsReceiver;
+import io.appium.settings.receivers.SmsReader;
+import io.appium.settings.receivers.UnpairBluetoothDevicesReceiver;
+import io.appium.settings.receivers.WiFiConnectionSettingReceiver;
 
 public class ForegroundService extends Service {
     private static final String TAG = "APPIUM SERVICE";
     public static final String ACTION_START = "start";
     public static final String ACTION_STOP = "stop";
+
+    private final List<BroadcastReceiver> settingsReceivers = new ArrayList<>();
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -49,6 +70,28 @@ public class ForegroundService extends Service {
         return super.onStartCommand(intent, flags, startId);
     }
 
+    @Override public void onCreate() {
+        registerSettingsReceivers(Arrays.asList(
+                WiFiConnectionSettingReceiver.class,
+                AnimationSettingReceiver.class,
+                DataConnectionSettingReceiver.class,
+                LocaleSettingReceiver.class,
+                LocalesReader.class,
+                LocationInfoReceiver.class,
+                ClipboardReceiver.class,
+                BluetoothConnectionSettingReceiver.class,
+                UnpairBluetoothDevicesReceiver.class,
+                NotificationsReceiver.class,
+                SmsReader.class,
+                MediaScannerReceiver.class
+        ));
+    }
+
+    @Override public void onDestroy() {
+        stopBroadCastReceiver();
+        super.onDestroy();
+    }
+
     private void startForegroundService() {
         startForeground(NotificationHelpers.APPIUM_NOTIFICATION_IDENTIFIER,
                 NotificationHelpers.getNotification(this));
@@ -66,5 +109,34 @@ public class ForegroundService extends Service {
         Intent intent = new Intent(context, ForegroundService.class);
         intent.setAction(ForegroundService.ACTION_START);
         return intent;
+    }
+
+    private void registerSettingsReceivers(List<Class<? extends BroadcastReceiver>> receiverClasses)
+    {
+        for (Class<? extends BroadcastReceiver> receiverClass: receiverClasses) {
+            try {
+                final BroadcastReceiver receiver = receiverClass.newInstance();
+                IntentFilter filter = new IntentFilter(((HasAction) receiver).getAction());
+                getApplicationContext().registerReceiver(receiver, filter);
+                Log.d(TAG, "Register " + receiver);
+                settingsReceivers.add(receiver);
+            } catch (IllegalAccessException e) {
+                Log.e(TAG, "Failed to register the receiver: " + receiverClass, e);
+            } catch (InstantiationException e) {
+                Log.e(TAG, "Failed to register the receiver: " + receiverClass, e);
+            }
+        }
+    }
+
+    private void stopBroadCastReceiver() {
+        for (BroadcastReceiver receiver: settingsReceivers) {
+            Log.d(TAG, "Unregister " + receiver);
+            try {
+                getApplicationContext().unregisterReceiver(receiver);
+            } catch (IllegalArgumentException e) {
+                // Can be ignored, so just for debugging purpose
+                Log.w(TAG, "Got an error in unregisterReceiver: " + receiver, e);
+            }
+        }
     }
 }

--- a/app/src/main/java/io/appium/settings/ForegroundService.java
+++ b/app/src/main/java/io/appium/settings/ForegroundService.java
@@ -59,7 +59,7 @@ public class ForegroundService extends Service {
     public void onCreate() {
         super.onCreate();
         settingsReceivers.addAll(
-                SettingsReceivers.Register(getApplicationContext())
+                SettingsReceivers.register(getApplicationContext())
         );
     }
 
@@ -89,6 +89,6 @@ public class ForegroundService extends Service {
     }
 
     private void stopBroadCastReceiver() {
-        SettingsReceivers.Unregister(getApplicationContext(), settingsReceivers);
+        SettingsReceivers.unregister(getApplicationContext(), settingsReceivers);
     }
 }

--- a/app/src/main/java/io/appium/settings/ForegroundService.java
+++ b/app/src/main/java/io/appium/settings/ForegroundService.java
@@ -56,14 +56,15 @@ public class ForegroundService extends Service {
     }
 
     @Override public void onCreate() {
+        super.onCreate();
         settingsReceivers.addAll(
                 SettingsReceivers.Register(getApplicationContext())
         );
     }
 
     @Override public void onDestroy() {
-        stopBroadCastReceiver();
         super.onDestroy();
+        stopBroadCastReceiver();
     }
 
     private void startForegroundService() {

--- a/app/src/main/java/io/appium/settings/ForegroundService.java
+++ b/app/src/main/java/io/appium/settings/ForegroundService.java
@@ -20,28 +20,13 @@ import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.os.IBinder;
 import android.util.Log;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import io.appium.settings.helpers.NotificationHelpers;
-import io.appium.settings.receivers.AnimationSettingReceiver;
-import io.appium.settings.receivers.BluetoothConnectionSettingReceiver;
-import io.appium.settings.receivers.ClipboardReceiver;
-import io.appium.settings.receivers.DataConnectionSettingReceiver;
-import io.appium.settings.receivers.HasAction;
-import io.appium.settings.receivers.LocaleSettingReceiver;
-import io.appium.settings.receivers.LocalesReader;
-import io.appium.settings.receivers.LocationInfoReceiver;
-import io.appium.settings.receivers.MediaScannerReceiver;
-import io.appium.settings.receivers.NotificationsReceiver;
-import io.appium.settings.receivers.SmsReader;
-import io.appium.settings.receivers.UnpairBluetoothDevicesReceiver;
-import io.appium.settings.receivers.WiFiConnectionSettingReceiver;
 
 public class ForegroundService extends Service {
     private static final String TAG = "APPIUM SERVICE";
@@ -71,20 +56,9 @@ public class ForegroundService extends Service {
     }
 
     @Override public void onCreate() {
-        registerSettingsReceivers(Arrays.asList(
-                WiFiConnectionSettingReceiver.class,
-                AnimationSettingReceiver.class,
-                DataConnectionSettingReceiver.class,
-                LocaleSettingReceiver.class,
-                LocalesReader.class,
-                LocationInfoReceiver.class,
-                ClipboardReceiver.class,
-                BluetoothConnectionSettingReceiver.class,
-                UnpairBluetoothDevicesReceiver.class,
-                NotificationsReceiver.class,
-                SmsReader.class,
-                MediaScannerReceiver.class
-        ));
+        settingsReceivers.addAll(
+                SettingsReceivers.Register(getApplicationContext())
+        );
     }
 
     @Override public void onDestroy() {
@@ -111,32 +85,7 @@ public class ForegroundService extends Service {
         return intent;
     }
 
-    private void registerSettingsReceivers(List<Class<? extends BroadcastReceiver>> receiverClasses)
-    {
-        for (Class<? extends BroadcastReceiver> receiverClass: receiverClasses) {
-            try {
-                final BroadcastReceiver receiver = receiverClass.newInstance();
-                IntentFilter filter = new IntentFilter(((HasAction) receiver).getAction());
-                getApplicationContext().registerReceiver(receiver, filter);
-                Log.d(TAG, "Register " + receiver);
-                settingsReceivers.add(receiver);
-            } catch (IllegalAccessException e) {
-                Log.e(TAG, "Failed to register the receiver: " + receiverClass, e);
-            } catch (InstantiationException e) {
-                Log.e(TAG, "Failed to register the receiver: " + receiverClass, e);
-            }
-        }
-    }
-
     private void stopBroadCastReceiver() {
-        for (BroadcastReceiver receiver: settingsReceivers) {
-            Log.d(TAG, "Unregister " + receiver);
-            try {
-                getApplicationContext().unregisterReceiver(receiver);
-            } catch (IllegalArgumentException e) {
-                // Can be ignored, so just for debugging purpose
-                Log.w(TAG, "Got an error in unregisterReceiver: " + receiver, e);
-            }
-        }
+        SettingsReceivers.Unregister(getApplicationContext(), settingsReceivers);
     }
 }

--- a/app/src/main/java/io/appium/settings/ForegroundService.java
+++ b/app/src/main/java/io/appium/settings/ForegroundService.java
@@ -55,14 +55,16 @@ public class ForegroundService extends Service {
         return super.onStartCommand(intent, flags, startId);
     }
 
-    @Override public void onCreate() {
+    @Override
+    public void onCreate() {
         super.onCreate();
         settingsReceivers.addAll(
                 SettingsReceivers.Register(getApplicationContext())
         );
     }
 
-    @Override public void onDestroy() {
+    @Override
+    public void onDestroy() {
         super.onDestroy();
         stopBroadCastReceiver();
     }

--- a/app/src/main/java/io/appium/settings/ForegroundService.java
+++ b/app/src/main/java/io/appium/settings/ForegroundService.java
@@ -66,7 +66,7 @@ public class ForegroundService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        stopBroadCastReceiver();
+        SettingsReceivers.unregister(getApplicationContext(), settingsReceivers);
     }
 
     private void startForegroundService() {
@@ -86,9 +86,5 @@ public class ForegroundService extends Service {
         Intent intent = new Intent(context, ForegroundService.class);
         intent.setAction(ForegroundService.ACTION_START);
         return intent;
-    }
-
-    private void stopBroadCastReceiver() {
-        SettingsReceivers.unregister(getApplicationContext(), settingsReceivers);
     }
 }

--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -120,7 +120,7 @@ public class Settings extends Activity {
                 unregisterReceiver(receiver);
             } catch (IllegalArgumentException e) {
                 // Can be ignored, so just for debugging purpose
-                Log.d(TAG, "Got an error in unregisterReceiver: " + receiver.getClass(), e);
+                Log.d(TAG, "Got an error in unregisterReceiver(" + receiver + "): " + e.getMessage());
             }
         }
         ;

--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -70,7 +70,7 @@ public class Settings extends Activity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 startForegroundService(ForegroundService.getForegroundServiceIntent(Settings.this));
             } else {
-                SettingsReceivers.Register(getApplicationContext());
+                SettingsReceivers.register(getApplicationContext());
                 LocationTracker.getInstance().start(this);
             }
         }

--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -68,6 +68,7 @@ public class Settings extends Activity {
         } else {
             // https://developer.android.com/about/versions/oreo/background-location-limits
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                // The ForegroundService handles SettingsReceivers registration.
                 startForegroundService(ForegroundService.getForegroundServiceIntent(Settings.this));
             } else {
                 SettingsReceivers.register(getApplicationContext());

--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -17,7 +17,6 @@
 package io.appium.settings;
 
 import android.app.Activity;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.media.projection.MediaProjectionManager;
@@ -28,8 +27,6 @@ import android.util.Log;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 
 import io.appium.settings.recorder.RecorderService;
 import io.appium.settings.recorder.RecorderUtil;
@@ -59,8 +56,6 @@ public class Settings extends Activity {
     private int recordingMaxDuration = RECORDING_MAX_DURATION_DEFAULT_MS;
     private String recordingResolutionMode = NO_RESOLUTION_MODE_SET;
 
-    private final List<BroadcastReceiver> settingsReceivers = new ArrayList<>();
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -75,9 +70,7 @@ public class Settings extends Activity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 startForegroundService(ForegroundService.getForegroundServiceIntent(Settings.this));
             } else {
-                settingsReceivers.addAll(
-                        SettingsReceivers.Register(getApplicationContext())
-                );
+                SettingsReceivers.Register(getApplicationContext());
                 LocationTracker.getInstance().start(this);
             }
         }

--- a/app/src/main/java/io/appium/settings/Settings.java
+++ b/app/src/main/java/io/appium/settings/Settings.java
@@ -17,6 +17,7 @@
 package io.appium.settings;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.media.projection.MediaProjectionManager;
@@ -27,6 +28,9 @@ import android.util.Log;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
 import io.appium.settings.recorder.RecorderService;
 import io.appium.settings.recorder.RecorderUtil;
 
@@ -55,6 +59,7 @@ public class Settings extends Activity {
     private int recordingMaxDuration = RECORDING_MAX_DURATION_DEFAULT_MS;
     private String recordingResolutionMode = NO_RESOLUTION_MODE_SET;
 
+    private final List<BroadcastReceiver> settingsReceivers = new ArrayList<>();
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -70,6 +75,9 @@ public class Settings extends Activity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 startForegroundService(ForegroundService.getForegroundServiceIntent(Settings.this));
             } else {
+                settingsReceivers.addAll(
+                        SettingsReceivers.Register(getApplicationContext())
+                );
                 LocationTracker.getInstance().start(this);
             }
         }

--- a/app/src/main/java/io/appium/settings/SettingsReceivers.java
+++ b/app/src/main/java/io/appium/settings/SettingsReceivers.java
@@ -62,6 +62,11 @@ public class SettingsReceivers {
     }
 
     static void unregister(Context applicationContext, List<BroadcastReceiver> settingsReceivers) {
+        if (settingsReceivers.isEmpty()) {
+            Log.d(TAG, "Nothing has registered");
+            return;
+        }
+
         for (BroadcastReceiver receiver: settingsReceivers) {
             Log.d(TAG, "Unregister " + receiver);
             try {

--- a/app/src/main/java/io/appium/settings/SettingsReceivers.java
+++ b/app/src/main/java/io/appium/settings/SettingsReceivers.java
@@ -26,7 +26,7 @@ import io.appium.settings.receivers.WiFiConnectionSettingReceiver;
 public class SettingsReceivers {
     private static final String TAG = "APPIUM SERVICE";
 
-    static List<BroadcastReceiver> Register(Context context) {
+    static List<BroadcastReceiver> Register(Context applicationContext) {
         List<Class<? extends BroadcastReceiver>> receiverClasses = Arrays.asList(
                 WiFiConnectionSettingReceiver.class,
                 AnimationSettingReceiver.class,
@@ -47,7 +47,7 @@ public class SettingsReceivers {
             try {
                 final BroadcastReceiver receiver = receiverClass.newInstance();
                 IntentFilter filter = new IntentFilter(((HasAction) receiver).getAction());
-                context.registerReceiver(receiver, filter);
+                applicationContext.registerReceiver(receiver, filter);
                 Log.d(TAG, "Register " + receiver);
                 settingsReceivers.add(receiver);
             } catch (IllegalAccessException e) {
@@ -59,13 +59,12 @@ public class SettingsReceivers {
         return settingsReceivers;
     }
 
-    static void Unregister(Context context, List<BroadcastReceiver> settingsReceivers) {
+    static void Unregister(Context applicationContext, List<BroadcastReceiver> settingsReceivers) {
         for (BroadcastReceiver receiver: settingsReceivers) {
             Log.d(TAG, "Unregister " + receiver);
             try {
-                context.unregisterReceiver(receiver);
+                applicationContext.unregisterReceiver(receiver);
             } catch (IllegalArgumentException e) {
-                // Can be ignored, so just for debugging purpose
                 Log.w(TAG, "Got an error in unregisterReceiver: " + receiver, e);
             }
         }

--- a/app/src/main/java/io/appium/settings/SettingsReceivers.java
+++ b/app/src/main/java/io/appium/settings/SettingsReceivers.java
@@ -1,0 +1,73 @@
+package io.appium.settings;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.IntentFilter;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.appium.settings.receivers.AnimationSettingReceiver;
+import io.appium.settings.receivers.BluetoothConnectionSettingReceiver;
+import io.appium.settings.receivers.ClipboardReceiver;
+import io.appium.settings.receivers.DataConnectionSettingReceiver;
+import io.appium.settings.receivers.HasAction;
+import io.appium.settings.receivers.LocaleSettingReceiver;
+import io.appium.settings.receivers.LocalesReader;
+import io.appium.settings.receivers.LocationInfoReceiver;
+import io.appium.settings.receivers.MediaScannerReceiver;
+import io.appium.settings.receivers.NotificationsReceiver;
+import io.appium.settings.receivers.SmsReader;
+import io.appium.settings.receivers.UnpairBluetoothDevicesReceiver;
+import io.appium.settings.receivers.WiFiConnectionSettingReceiver;
+
+public class SettingsReceivers {
+    private static final String TAG = "APPIUM SERVICE";
+
+    static List<BroadcastReceiver> Register(Context context) {
+        List<Class<? extends BroadcastReceiver>> receiverClasses = Arrays.asList(
+                WiFiConnectionSettingReceiver.class,
+                AnimationSettingReceiver.class,
+                DataConnectionSettingReceiver.class,
+                LocaleSettingReceiver.class,
+                LocalesReader.class,
+                LocationInfoReceiver.class,
+                ClipboardReceiver.class,
+                BluetoothConnectionSettingReceiver.class,
+                UnpairBluetoothDevicesReceiver.class,
+                NotificationsReceiver.class,
+                SmsReader.class,
+                MediaScannerReceiver.class
+        );
+
+        List<BroadcastReceiver> settingsReceivers = new ArrayList<>();
+        for (Class<? extends BroadcastReceiver> receiverClass: receiverClasses) {
+            try {
+                final BroadcastReceiver receiver = receiverClass.newInstance();
+                IntentFilter filter = new IntentFilter(((HasAction) receiver).getAction());
+                context.registerReceiver(receiver, filter);
+                Log.d(TAG, "Register " + receiver);
+                settingsReceivers.add(receiver);
+            } catch (IllegalAccessException e) {
+                Log.e(TAG, "Failed to register the receiver: " + receiverClass, e);
+            } catch (InstantiationException e) {
+                Log.e(TAG, "Failed to register the receiver: " + receiverClass, e);
+            }
+        }
+        return settingsReceivers;
+    }
+
+    static void Unregister(Context context, List<BroadcastReceiver> settingsReceivers) {
+        for (BroadcastReceiver receiver: settingsReceivers) {
+            Log.d(TAG, "Unregister " + receiver);
+            try {
+                context.unregisterReceiver(receiver);
+            } catch (IllegalArgumentException e) {
+                // Can be ignored, so just for debugging purpose
+                Log.w(TAG, "Got an error in unregisterReceiver: " + receiver, e);
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/appium/settings/SettingsReceivers.java
+++ b/app/src/main/java/io/appium/settings/SettingsReceivers.java
@@ -3,7 +3,10 @@ package io.appium.settings;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.util.Log;
+
+import androidx.annotation.RequiresApi;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,6 +29,7 @@ import io.appium.settings.receivers.WiFiConnectionSettingReceiver;
 public class SettingsReceivers {
     private static final String TAG = "APPIUM SERVICE";
 
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
     static List<BroadcastReceiver> register(Context applicationContext) {
         List<Class<? extends BroadcastReceiver>> receiverClasses = Arrays.asList(
                 WiFiConnectionSettingReceiver.class,
@@ -50,9 +54,7 @@ public class SettingsReceivers {
                 applicationContext.registerReceiver(receiver, filter);
                 Log.d(TAG, "Register " + receiver);
                 settingsReceivers.add(receiver);
-            } catch (IllegalAccessException e) {
-                Log.e(TAG, "Failed to register the receiver: " + receiverClass, e);
-            } catch (InstantiationException e) {
+            } catch (IllegalAccessException | InstantiationException e) {
                 Log.e(TAG, "Failed to register the receiver: " + receiverClass, e);
             }
         }

--- a/app/src/main/java/io/appium/settings/SettingsReceivers.java
+++ b/app/src/main/java/io/appium/settings/SettingsReceivers.java
@@ -26,7 +26,7 @@ import io.appium.settings.receivers.WiFiConnectionSettingReceiver;
 public class SettingsReceivers {
     private static final String TAG = "APPIUM SERVICE";
 
-    static List<BroadcastReceiver> Register(Context applicationContext) {
+    static List<BroadcastReceiver> register(Context applicationContext) {
         List<Class<? extends BroadcastReceiver>> receiverClasses = Arrays.asList(
                 WiFiConnectionSettingReceiver.class,
                 AnimationSettingReceiver.class,
@@ -59,7 +59,7 @@ public class SettingsReceivers {
         return settingsReceivers;
     }
 
-    static void Unregister(Context applicationContext, List<BroadcastReceiver> settingsReceivers) {
+    static void unregister(Context applicationContext, List<BroadcastReceiver> settingsReceivers) {
         for (BroadcastReceiver receiver: settingsReceivers) {
             Log.d(TAG, "Unregister " + receiver);
             try {


### PR DESCRIPTION
The current method of registering broadcast receivers could keep adding the registration count. This causes https://github.com/appium/appium-uiautomator2-driver/issues/852 error:

> "message": "12-19 14:51:22.023 1664 1664 E AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{io.appium.settings/io.appium.settings.Settings}: java.lang.IllegalStateException: Too many receivers, total of 1000, registered for pid: 1664, callerPackage: io.appium.settings"

 especially when a user calls the recording feature.

After learning Android implementation practice, I think the registration on a service creation would be more appropriate since we expect such services need to keep running in foreground to work properly.

e.g.
```
kazu $ adb shell am broadcast -a io.appium.settings.location -n io.appium.settings/.receivers.LocationInfoReceiver --ez forceUpdate false
Broadcasting: Intent { act=io.appium.settings.location flg=0x400000 cmp=io.appium.settings/.receivers.LocationInfoReceiver (has extras) }
Broadcast completed: result=-1, data="37.3950779 -122.0991884 -5.3000002"
```

Also, this PR skips calling foreground app start when the activity starts for recorder usage.

I have manually tested if this foreground method has an issue on my local, but it looks good so far.