### PR TITLE
fix: crash while enabling/disabling bluetooth on API level >= 31

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,8 +23,12 @@
     <uses-permission android:name="android.permission.CHANGE_CONFIGURATION"
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.READ_SMS"
         tools:ignore="PermissionImpliesUnsupportedChromeOsHardware" />
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>


### PR DESCRIPTION
## Description

This PR fixes a crash that happened while trying to enabling/disabling bluetooth in devices with API level >= 31.

Just adding the missing `BLUETOOTH_CONNECT` permission fixes the issue. I added also `BLUETOOTH_SCAN` to enable future use cases for starting Bluetooth scans (not sure if will ever be used).

<details>
  <summary>Stack trace</summary>
  

```
FATAL EXCEPTION: main
Process: io.appium.settings, PID: 18440
java.lang.RuntimeException: Error receiving broadcast Intent { act=io.appium.settings.bluetooth flg=0x400010 (has extras) } in io.appium.settings.receivers.BluetoothConnectionSettingReceiver@f2d9c69
	at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0(LoadedApk.java:1818)
	at android.app.LoadedApk$ReceiverDispatcher$Args.$r8$lambda$mcNAAl1SQ4MyJPyDg8TJ2x2h0Rk(Unknown Source:0)
	at android.app.LoadedApk$ReceiverDispatcher$Args$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8501)

                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
Caused by: java.lang.SecurityException: Need android.permission.BLUETOOTH_CONNECT permission for android.content.AttributionSource@e180441b: disable
	at android.os.Parcel.createExceptionOrNull(Parcel.java:3182)
	at android.os.Parcel.createException(Parcel.java:3166)
	at android.os.Parcel.readException(Parcel.java:3149)
	at android.os.Parcel.readException(Parcel.java:3091)
	at android.bluetooth.IBluetoothManager$Stub$Proxy.disable(IBluetoothManager.java:554)
	at android.bluetooth.BluetoothAdapter.disable(BluetoothAdapter.java:1641)
	at android.bluetooth.BluetoothAdapter.disable(BluetoothAdapter.java:1622)
	at io.appium.settings.handlers.BluetoothConnectionSettingHandler.setState(BluetoothConnectionSettingHandler.java:35)
	at io.appium.settings.handlers.AbstractSettingHandler.disable(AbstractSettingHandler.java:46)
	at io.appium.settings.receivers.AbstractSettingReceiver.onReceive(AbstractSettingReceiver.java:56)
	at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0(LoadedApk.java:1810)
	at android.app.LoadedApk$ReceiverDispatcher$Args.$r8$lambda$mcNAAl1SQ4MyJPyDg8TJ2x2h0Rk(Unknown Source:0) 
	at android.app.LoadedApk$ReceiverDispatcher$Args$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0) 
	at android.os.Handler.handleCallback(Handler.java:959) 
	at android.os.Handler.dispatchMessage(Handler.java:100) 
	at android.os.Looper.loopOnce(Looper.java:232) 
	at android.os.Looper.loop(Looper.java:317) 
	at android.app.ActivityThread.main(ActivityThread.java:8501) 

                                                                                                    	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878) 
Caused by: android.os.RemoteException: Remote stack trace:
	at com.android.server.bluetooth.BtPermissionUtils.checkConnectPermissionForDataDelivery(BtPermissionUtils.java:100)
	at com.android.server.bluetooth.BtPermissionUtils.checkBluetoothPermissions(BtPermissionUtils.java:336)
	at com.android.server.bluetooth.BtPermissionUtils.callerCanToggle(BtPermissionUtils.java:123)
	at com.android.server.bluetooth.BluetoothServiceBinder.disable(BluetoothServiceBinder.java:157)
	at android.bluetooth.IBluetoothManager$Stub.onTransact(IBluetoothManager.java:296)

```
  
</details>
