### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "url": "https://github.com/appium/io.appium.settings.git"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "keywords": [
     "appium",
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/appium/io.appium.settings",
   "dependencies": {
-    "@appium/logger": "^1.3.0",
+    "@appium/logger": "^2.0.0-rc.1",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.5.1",
     "lodash": "^4.2.1",
@@ -53,17 +53,17 @@
     "teen_process": "^2.0.0"
   },
   "devDependencies": {
-    "@appium/test-support": "^3.0.1",
-    "@appium/eslint-config-appium-ts": "^1.x",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/test-support": "^4.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",
     "@types/lodash": "^4.14.196",
     "@types/node": "^24.0.0",
     "@types/teen_process": "^2.0.2",
-    "appium-adb": "^12.4.0",
+    "appium-adb": "^13.0.0",
     "chai": "^5.1.1",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.2.1",
     "semver": "^7.5.4",
     "source-map-support": "^0.x",
-    "teen_process": "^2.0.0"
+    "teen_process": "^3.0.0"
   },
   "devDependencies": {
     "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10