### PR TITLE
refactor: use native trim instead of lodash.trim

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,4 @@
 import { log, LOG_PREFIX } from './logger';
-import _ from 'lodash';
 import { waitForCondition } from 'asyncbox';
 import { SETTINGS_HELPER_ID, SETTINGS_HELPER_MAIN_ACTIVITY } from './constants.js';
 import { setAnimationState } from './commands/animation';
@@ -171,7 +170,7 @@ export class SettingsApp {
         'Check the server log for more details'
       );
     }
-    const jsonStr = _.trim(match[1]);
+    const jsonStr = match[1].trim();
     try {
       return JSON.parse(jsonStr);
     } catch {

--- a/lib/commands/clipboard.js
+++ b/lib/commands/clipboard.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { LOG_PREFIX } from '../logger';
 import {
   CLIPBOARD_RECEIVER,
@@ -42,5 +41,5 @@ export async function getClipboard () {
   if (!match) {
     throw new Error(`Cannot parse the actual clipboard content from the command output: ${output}`);
   }
-  return _.trim(match[1]);
+  return match[1].trim();
 }


### PR DESCRIPTION
replace lodash.trim with the native trim to reduce the dependency on lodash