### PR TITLE
fix: call stop service explicitly for foreground service

### DIFF
--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -71,6 +71,7 @@ public class LocationService extends Service {
             if (getApplicationContext().checkCallingOrSelfPermission(p)
                     != PackageManager.PERMISSION_GRANTED) {
                 Log.e(TAG, String.format("Cannot mock location due to missing permission '%s'", p));
+                stopSelf();
                 return START_NOT_STICKY;
             }
         }
@@ -79,9 +80,16 @@ public class LocationService extends Service {
         // https://developer.android.com/about/versions/oreo/android-8.0-changes.html
         finishForegroundSetup();
 
+        if (intent == null) {
+            Log.w(TAG, "Null intent received. Stopping mock location service");
+            stopForeground(true);
+            stopSelf();
+            return START_NOT_STICKY;
+        }
+
         handleIntent(intent);
 
-        return START_STICKY;
+        return START_NOT_STICKY;
     }
 
     @Override
@@ -89,13 +97,11 @@ public class LocationService extends Service {
         Log.i(TAG, "Shutting down MockLocationService");
         locationUpdatesTimer.cancel();
         disableLocationProviders();
+        stopForeground(true);
         super.onDestroy();
     }
 
     private void handleIntent(Intent intent) {
-        if (intent == null) {
-            return;
-        }
         Log.i(TAG, "INTENT " + intent.getExtras());
 
         scheduleLocationUpdate(intent);

--- a/app/src/main/java/io/appium/settings/LocationService.java
+++ b/app/src/main/java/io/appium/settings/LocationService.java
@@ -89,7 +89,7 @@ public class LocationService extends Service {
 
         handleIntent(intent);
 
-        return START_NOT_STICKY;
+        return START_STICKY;
     }
 
     @Override

--- a/app/src/main/java/io/appium/settings/recorder/RecorderService.java
+++ b/app/src/main/java/io/appium/settings/recorder/RecorderService.java
@@ -58,7 +58,6 @@ public class RecorderService extends Service {
         if (recorderThread != null && recorderThread.isRecordingRunning()) {
             recorderThread.stopRecording();
         }
-        stopForeground(true);
         super.onDestroy();
     }
 

--- a/app/src/main/java/io/appium/settings/recorder/RecorderService.java
+++ b/app/src/main/java/io/appium/settings/recorder/RecorderService.java
@@ -133,17 +133,17 @@ public class RecorderService extends Service {
         }
 
         int resultCode = intent.getIntExtra(ACTION_RECORDING_RESULT_CODE, 0);
-        // get MediaProjection
-        final MediaProjection projection = mediaProjectionManager.getMediaProjection(resultCode,
-                intent);
-        if (projection == null) {
-            Log.e(TAG, "Recording is stopped, Unable to retrieve MediaProjection instance");
-            return false;
-        }
 
         String outputFilePath = intent.getStringExtra(ACTION_RECORDING_FILENAME);
         if (outputFilePath == null) {
             Log.e(TAG, "Recording is stopped, Unable to retrieve outputFilePath instance");
+            return false;
+        }
+
+        final MediaProjection projection = mediaProjectionManager.getMediaProjection(resultCode,
+                intent);
+        if (projection == null) {
+            Log.e(TAG, "Recording is stopped, Unable to retrieve MediaProjection instance");
             return false;
         }
 

--- a/app/src/main/java/io/appium/settings/recorder/RecorderService.java
+++ b/app/src/main/java/io/appium/settings/recorder/RecorderService.java
@@ -58,6 +58,7 @@ public class RecorderService extends Service {
         if (recorderThread != null && recorderThread.isRecordingRunning()) {
             recorderThread.stopRecording();
         }
+        stopForeground(true);
         super.onDestroy();
     }
 
@@ -72,11 +73,13 @@ public class RecorderService extends Service {
     public int onStartCommand(final Intent intent, final int flags, final int startId) {
         if (intent == null) {
             Log.e(TAG, "onStartCommand: Unable to retrieve recording intent");
+            stopRecord();
             return START_NOT_STICKY;
         }
         final String action = intent.getAction();
         if (action == null) {
             Log.e(TAG, "onStartCommand: Unable to retrieve recording intent:action");
+            stopRecord();
             return START_NOT_STICKY;
         }
 
@@ -88,10 +91,15 @@ public class RecorderService extends Service {
                     (MediaProjectionManager) getSystemService(Context.MEDIA_PROJECTION_SERVICE);
 
             if (mMediaProjectionManager != null) {
-                startRecord(mMediaProjectionManager, intent);
+                final boolean isStarted = startRecord(mMediaProjectionManager, intent);
+                if (!isStarted) {
+                    stopRecord();
+                    result = START_NOT_STICKY;
+                }
             } else {
                 Log.e(TAG, "onStartCommand: " +
                         "Unable to retrieve MediaProjectionManager instance");
+                stopRecord();
                 result = START_NOT_STICKY;
             }
         } else if (ACTION_RECORDING_STOP.equals(action)) {
@@ -101,6 +109,7 @@ public class RecorderService extends Service {
         } else {
             Log.v(TAG, "onStartCommand: Received unknown recording intent with action: "
                     + action);
+            stopRecord();
             result = START_NOT_STICKY;
         }
 
@@ -111,12 +120,12 @@ public class RecorderService extends Service {
      * start recording
      */
     @RequiresApi(api = Build.VERSION_CODES.Q)
-    private void startRecord(MediaProjectionManager mediaProjectionManager,
-                             final Intent intent) {
+    private boolean startRecord(MediaProjectionManager mediaProjectionManager,
+                                final Intent intent) {
         if (recorderThread != null) {
             if (recorderThread.isRecordingRunning()) {
                 Log.v(TAG, "Recording is already continuing, exiting");
-                return;
+                return true;
             } else {
                 Log.w(TAG, "Recording is stopped, " +
                         "but recording instance is still alive, starting recording");
@@ -130,13 +139,13 @@ public class RecorderService extends Service {
                 intent);
         if (projection == null) {
             Log.e(TAG, "Recording is stopped, Unable to retrieve MediaProjection instance");
-            return;
+            return false;
         }
 
         String outputFilePath = intent.getStringExtra(ACTION_RECORDING_FILENAME);
         if (outputFilePath == null) {
             Log.e(TAG, "Recording is stopped, Unable to retrieve outputFilePath instance");
-            return;
+            return false;
         }
 
         /* TODO we need to rotate frames that comes from virtual screen before writing to file via muxer,
@@ -181,6 +190,7 @@ public class RecorderService extends Service {
                 resolutionWidth, resolutionHeight, rawDpi,
                 recordingRotationDegree, recordingPriority, recordingMaxDuration);
         recorderThread.startRecording();
+        return true;
     }
 
     /**
@@ -191,6 +201,7 @@ public class RecorderService extends Service {
             recorderThread.stopRecording();
             recorderThread = null;
         }
+        stopForeground(true);
         stopSelf();
     }
 


### PR DESCRIPTION
Fixes https://github.com/appium/io.appium.settings/issues/290

This might not be "required" since when a service stops fully, generally foreground stuff also stops fully. Although, no reason to not call them explicitly.