### PR TITLE
chore: downgrade conventional-changelog-conventionalcommits to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "appium-adb": "^15.0.0",
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "mocha": "^11.0.1",
     "prettier": "^3.9.3",
     "semantic-release": "^25.0.2",


### PR DESCRIPTION
https://github.com/appium/appium-safari-driver/pull/177